### PR TITLE
Add .stestr directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /dist
 /.testrepository
+/.stestr
 /testrepository.egg-info
 __pycache__
 *.pyc


### PR DESCRIPTION
We don't need to track this in a git repository.

I'm not sure the ".stestr" is your intentional or not, though :)
