### PR TITLE
Fix command name - testr to stestr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages =
 
 [entry_points]
 console_scripts =
-    testr = stestr.cli:main
+    stestr = stestr.cli:main
 
 
 [build_sphinx]


### PR DESCRIPTION
This commit fixes the command name 'testr' to 'stestr'. I think we
should avoid the command name confliction.

Is this your intention?