### PR TITLE
Add py35 to tox.ini envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py34,py27,pep8
+envlist = py35,py34,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit adds py35 to tox.ini envlist. Because py35 is the default
python3 version in Ubuntu xenial.