### PR TITLE
Fix concurrency option type to int

### DIFF
--- a/stestr/test_listing_fixture.py
+++ b/stestr/test_listing_fixture.py
@@ -103,7 +103,7 @@ class TestListingFixture(fixtures.Fixture):
         else:
             self.concurrency = None
             if hasattr(self.options, 'concurrency'):
-                self.concurrency = self.options.concurrency
+                self.concurrency = int(self.options.concurrency)
             if not self.concurrency:
                 self.concurrency = scheduler.local_concurrency()
             if not self.concurrency:


### PR DESCRIPTION
This commit fixes the concurrency option from str to int in the run
command. In python3, we need to make it convert to an int value,
explicitly. Otherwise, "TypeError: 'str' object cannot be interpreted as
an integer" error occurs.