### PR TITLE
Add Python 3.5 to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
 
 [files]
 packages =


### PR DESCRIPTION
This commit adds Python 3.5 support to setup.cfg. That version is
already included in tox.ini. So we can also add it to setup.cfg.