### PR TITLE
Remove /.testrepository from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ AUTHORS
 ChangeLog
 /build
 /dist
-/.testrepository
 /.stestr
 /testrepository.egg-info
 __pycache__


### PR DESCRIPTION
This commit removes '/.testrepository' from .gitignore. We don't make
that directory anymore, so we don't need to ignore it.