### PR TITLE
Add serial option to CLI

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -139,9 +139,10 @@ to regex filter the tests.
 Parallel testing
 ----------------
 
-stestr lets you run tests in parallel. It actually does this by def::
+stestr lets you run tests in parallel by default. So, it actually does this by
+def::
 
-  $ stestr run --parallel
+  $ stestr run
 
 This will first list the tests, partition the tests into one partition per CPU
 on the machine, and then invoke multiple test runners at the same time, with
@@ -154,7 +155,7 @@ use the multiprocessing Python module On operating systems where this is not
 implemented, or if you need to control the number of workers that are used,
 the --concurrency option will let you do so::
 
-  $ stestr run --parallel --concurrency=2
+  $ stestr run --concurrency=2
 
 When running tests in parallel, stestr adds a tag for each test to the subunit
 stream to show which worker executed that test. The tags are of the form

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -34,9 +34,9 @@ def set_cli_opts(parser):
     parser.add_argument("--failing", action="store_true",
                         default=False,
                         help="Run only tests known to be failing.")
-    parser.add_argument("--parallel", action="store_true",
+    parser.add_argument("--serial", action="store_true",
                         default=False,
-                        help="Run tests in parallel processes.")
+                        help="Run tests in a serial processe.")
     parser.add_argument("--concurrency", action="store", default=0,
                         help="How many processes to use. The default (0) "
                              "autodetects your CPU count.")

--- a/stestr/test_listing_fixture.py
+++ b/stestr/test_listing_fixture.py
@@ -79,6 +79,8 @@ class TestListingFixture(fixtures.Fixture):
         self.idoption = idoption
         self.repository = repository
         self.parallel = parallel
+        if hasattr(options, 'serial') and options.serial:
+            self.parallel = False
         self._listpath = listpath
         self._parser = parser
         self.test_filters = test_filters

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -68,23 +68,23 @@ class TestReturnCodes(base.TestCase):
                              "return code of: %s" % (expected, p.returncode))
 
     def test_parallel_passing(self):
-        self.assertRunExit('stestr run --parallel passing', 0)
-
-    def test_parallel_fails(self):
-        self.assertRunExit('stestr run --parallel', 1)
-
-    def test_serial_passing(self):
         self.assertRunExit('stestr run passing', 0)
 
-    def test_serial_fails(self):
+    def test_parallel_fails(self):
         self.assertRunExit('stestr run', 1)
+
+    def test_serial_passing(self):
+        self.assertRunExit('stestr run --serial passing', 0)
+
+    def test_serial_fails(self):
+        self.assertRunExit('stestr run --serial', 1)
 
     def test_serial_subunit_passing(self):
         self.assertRunExit('stestr run --subunit passing', 0,
                            subunit=True)
 
     def test_parallel_subunit_passing(self):
-        self.assertRunExit('stestr run --parallel --subunit passing', 0,
+        self.assertRunExit('stestr run --subunit passing', 0,
                            subunit=True)
 
     def test_list(self):


### PR DESCRIPTION
This commit adds a --serial option and removes the --parallel option
because it is already by default. And this commit also updates
MANUAL.rst for it.

resolve #13 