### PR TITLE
Add line feed to stats command output

### DIFF
--- a/stestr/commands/stats.py
+++ b/stestr/commands/stats.py
@@ -27,5 +27,5 @@ def set_cli_opts(parser):
 
 def run(args):
     repo = util.get_repo_open(args[0].repo_type, args[0].repo_url)
-    sys.stdout.write('%s=%s' % ('runs', repo.count()))
+    sys.stdout.write('%s=%s\n' % ('runs', repo.count()))
     return 0


### PR DESCRIPTION
This commit adds a line feed to stats command output. Otherwise, it is
ugly.