### PR TITLE
Add CLI option to stestr run to randomize test order

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -295,6 +295,10 @@ example::
 would create 2 workers. The first would run all tests that match regex 1, and
 the second would run all tests that match regex 2 or regex 3.
 
+There is also an option on ``stestr run``, ``--random``/``-r`` to randomize the
+order of tests as they are passed to the workers. This is useful in certain
+use cases, especially when you want to test isolation between test cases.
+
 Automated test isolation bisection
 ----------------------------------
 

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -79,6 +79,9 @@ def set_cli_opts(parser):
                         help="Takes in a single test to bypasses test discover"
                              " and just execute the test specified. A file "
                              "name may be used in place of a test name.")
+    parser.add_argument('--random', '-r', action="store_true", default=False,
+                        help="Randomize the test order after they are "
+                             "partioned into separate workers")
 
 
 def get_cli_help():

--- a/stestr/scheduler.py
+++ b/stestr/scheduler.py
@@ -14,13 +14,15 @@ import collections
 import itertools
 import multiprocessing
 import operator
+import random
 
 import yaml
 
 from stestr import selection
 
 
-def partition_tests(test_ids, concurrency, repository, group_callback):
+def partition_tests(test_ids, concurrency, repository, group_callback,
+                    randomize=False):
         """Parition test_ids by concurrency.
 
         Test durations from the repository are used to get partitions which
@@ -38,6 +40,8 @@ def partition_tests(test_ids, concurrency, repository, group_callback):
             scheduling. This function expects a single test_id parameter and it
             will return a group identifier. Tests_ids that have the same group
             identifier will be kept on the same worker.
+        :param bool randomize: If true each partion's test order will be
+                            randomized
 
         :return: A list where each element is a distinct subset of test_ids,
             and the union of all the elements is equal to set(test_ids).
@@ -99,7 +103,15 @@ def partition_tests(test_ids, concurrency, repository, group_callback):
         # the partitions.
         for partition, group_id in zip(itertools.cycle(partitions), unknown):
             partition.extend(group_ids[group_id])
-        return partitions
+        if randomize:
+            out_parts = []
+            for partition in partitions:
+                temp_part = list(partition)
+                random.shuffle(temp_part)
+                out_parts.append(set(temp_part))
+            return out_parts
+        else:
+            return partitions
 
 
 def local_concurrency():

--- a/stestr/test_listing_fixture.py
+++ b/stestr/test_listing_fixture.py
@@ -219,8 +219,11 @@ class TestListingFixture(fixtures.Fixture):
             return [run_proc]
         # If there is a worker path, use that to get worker groups
         elif self.worker_path:
+            randomize = False
+            if hasattr(self.options, 'randomize'):
+                randomize = self.options.randomize
             test_id_groups = scheduler.generate_worker_partitions(
-                test_ids, self.worker_path)
+                test_ids, self.worker_path, randomize)
         # If we have multiple workers partition the tests and recursively
         # create single worker TestListingFixtures for each worker
         else:

--- a/stestr/tests/test_scheduler.py
+++ b/stestr/tests/test_scheduler.py
@@ -52,6 +52,17 @@ class TestScheduler(base.TestCase):
         self.assertEqual(3, len(partitions[0]))
         self.assertEqual(4, len(partitions[1]))
 
+    def test_random_partitions(self):
+        repo = memory.RepositoryFactory().initialise('memory:')
+        test_ids = frozenset(['a_test', 'b_test', 'c_test', 'd_test'])
+        sorted_parts = scheduler.partition_tests(test_ids, 2, repo, None)
+        random_parts = scheduler.partition_tests(test_ids, 2, repo, None,
+                                                 randomize=True)
+        self.assertNotEqual(sorted_parts, random_parts,
+                            "The sorted list %s is the same order as the "
+                            "shuffled list %s which is incorrect" % (
+                                sorted_parts, random_parts))
+
     def test_partition_tests_with_zero_duration(self):
         repo = memory.RepositoryFactory().initialise('memory:')
         result = repo.get_inserter()


### PR DESCRIPTION
This commit adds a new option to randomize the test order. This is
useful because in certain situations you want to introduce a bit
of entropy into the execution order. When this option is used the
same scheduler test partitioning strategy is used, but before the
list of tests is passed to subunit.run for execution the list is
shuffled.