### PR TITLE
Fix error stestr run with bad regex

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -328,6 +328,9 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
             partial = False
             if (failing or analyze_isolation or isolated):
                 partial = True
+            if not run_procs:
+                print("The specified regex doesn't match with anything.")
+                return 0
             return load.load((None, None), in_streams=run_procs,
                              partial=partial, subunit_out=subunit_out,
                              repo_type=cmd.options.repo_type,

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -70,6 +70,9 @@ class TestReturnCodes(base.TestCase):
     def test_parallel_passing(self):
         self.assertRunExit('stestr run passing', 0)
 
+    def test_parallel_passing_bad_regex(self):
+        self.assertRunExit('stestr run bad.regex.foobar', 0)
+
     def test_parallel_fails(self):
         self.assertRunExit('stestr run', 1)
 


### PR DESCRIPTION
This commit fixes an error when `stestr run` with a bad regex.

Fixes #36