### PR TITLE
Adds Windows support

### DIFF
--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -62,8 +62,10 @@ class TestrConf(object):
             top_dir = options.top_dir
         elif self.parser.has_option('DEFAULT', 'top_dir'):
             top_dir = self.parser.get('DEFAULT', 'top_dir')
-        command = "${PYTHON:-python} -m subunit.run discover -t" \
-                  " %s %s $LISTOPT $IDOPTION" % (top_dir, test_path)
+
+        python = 'python' if sys.platform == 'win32' else '${PYTHON:-python}'
+        command = "%s -m subunit.run discover -t" \
+                  " %s %s $LISTOPT $IDOPTION" % (python, top_dir, test_path)
         listopt = "--list"
         idoption = "--load-list $IDFILE"
         # If the command contains $IDOPTION read that command from config

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+
+from stestr import config_file
+from stestr.tests import base
+
+
+class TestTestrConf(base.TestCase):
+
+    @mock.patch.object(config_file.configparser, 'ConfigParser')
+    def setUp(self, mock_ConfigParser):
+        super(TestTestrConf, self).setUp()
+        self._testr_conf = config_file.TestrConf(mock.sentinel.config_file)
+        self._testr_conf.parser = mock.Mock()
+
+    @mock.patch.object(config_file.util, 'get_repo_open')
+    @mock.patch.object(config_file.test_listing_fixture, 'TestListingFixture')
+    @mock.patch.object(config_file, 'sys')
+    def _check_get_run_command(self, mock_sys, mock_TestListingFixture,
+                               mock_get_repo_open, platform='win32',
+                               expected_python='python'):
+        mock_sys.platform = platform
+        mock_options = mock.Mock()
+        mock_options.test_path = 'fake_test_path'
+        mock_options.top_dir = 'fake_top_dir'
+        mock_options.group_regex = '.*'
+
+        fixture = self._testr_conf.get_run_command(mock_options,
+                                                   mock.sentinel.test_ids,
+                                                   mock.sentinel.regexes)
+
+        self.assertEqual(mock_TestListingFixture.return_value, fixture)
+        mock_get_repo_open.assert_called_once_with(mock_options.repo_type,
+                                                   mock_options.repo_url)
+        command = "%s -m subunit.run discover -t %s %s $LISTOPT $IDOPTION" % (
+            expected_python, mock_options.top_dir, mock_options.test_path)
+        mock_TestListingFixture.assert_called_once_with(
+            mock.sentinel.test_ids, mock_options, command, "--list",
+            "--load-list $IDFILE", mock_get_repo_open.return_value,
+            test_filters=mock.sentinel.regexes, group_callback=mock.ANY)
+
+    def test_get_run_command_linux(self):
+        self._check_get_run_command(platform='linux2',
+                                    expected_python='${PYTHON:-python}')
+
+    def test_get_run_command_win32(self):
+        self._check_get_run_command()

--- a/stestr/tests/test_test_listing_fixture.py
+++ b/stestr/tests/test_test_listing_fixture.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+
+import mock
+
+from stestr import test_listing_fixture
+from stestr.tests import base
+
+
+class TestTestListingFixture(base.TestCase):
+
+    def setUp(self):
+        super(TestTestListingFixture, self).setUp()
+        self._fixture = test_listing_fixture.TestListingFixture(
+            mock.sentinel.test_ids, mock.sentinel.options,
+            mock.sentinel.cmd_template, mock.sentinel.listopt,
+            mock.sentinel.idoption, mock.sentinel.repository)
+
+    @mock.patch.object(subprocess, 'Popen')
+    @mock.patch.object(test_listing_fixture, 'sys')
+    def _check_start_process(self, mock_sys, mock_Popen, platform='win32',
+                             expected_fn=None):
+        mock_sys.platform = platform
+
+        self._fixture._start_process(mock.sentinel.cmd)
+
+        mock_Popen.assert_called_once_with(
+            mock.sentinel.cmd, shell=True, stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE, preexec_fn=expected_fn)
+
+    def test_start_process_win32(self):
+        self._check_start_process()
+
+    def test_start_process_linux(self):
+        self._check_start_process(
+            platform='linux2', expected_fn=self._fixture._clear_SIGPIPE)


### PR DESCRIPTION
dbm_gnu library does not exist on Windows. Uses anydbm on
Windows instead.
Passing preexec_fn to Popen is not supported on Windows. Passes
None instead.
Makes the list command more Windows-friendly on Windows.