### PR TITLE
Add support to stestr load to append to an existing entry

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -37,6 +37,9 @@ def set_cli_opts(parser):
     parser.add_argument("--subunit", action="store_true",
                         default=False,
                         help="Display results in subunit format.")
+    parser.add_argument("--id", "-i", default=None,
+                        help="Append the stream into an existing entry in the "
+                             "repository")
 
 
 def get_cli_help():
@@ -124,7 +127,13 @@ def load(arguments, in_streams=None, partial=False, subunit_out=False,
     if args:
         _subunit = getattr(args, 'subunit')
     _subunit_out = _subunit or subunit_out
-    inserter = repo.get_inserter(partial=partial_stream)
+    _run_id = None
+    if args:
+        _run_id = getattr(args, 'id')
+    if not _run_id:
+        inserter = repo.get_inserter(partial=partial_stream)
+    else:
+        inserter = repo.get_inserter(partial=partial_stream, run_id=_run_id)
     if _subunit_out:
         output_result, summary_result = output.make_result(inserter.get_id)
     else:

--- a/stestr/repository/abstract.py
+++ b/stestr/repository/abstract.py
@@ -67,7 +67,7 @@ class AbstractRepository(object):
         """
         raise NotImplementedError(self.get_failing)
 
-    def get_inserter(self, partial=False):
+    def get_inserter(self, partial=False, run_id=None):
         """Get an inserter that will insert a test run into the repository.
 
         Repository implementations should implement _get_inserter.
@@ -81,9 +81,9 @@ class AbstractRepository(object):
             that testtools 0.9.2 and above offer. The startTestRun and
             stopTestRun methods in particular must be called.
         """
-        return self._get_inserter(partial)
+        return self._get_inserter(partial, run_id)
 
-    def _get_inserter(self):
+    def _get_inserter(self, partial=False, run_id=None):
         """Get an inserter for get_inserter.
 
         The result is decorated with an AutoTimingTestResultDecorator.


### PR DESCRIPTION
This conmmit adds suport to the stestr load command and the underlying
repository API to append a stream into an existing entry in the DB. In
the repository API this is accomplished by adding a new optional
argument on the _get_inserter Abstract repository class to specify a
run_id. When specified the inserter returned will be for that already
existing entry in the repository. The stestr load command just leverages
this new mechanism by taking an id field on the cli and passing it to
the invocation of get_inserter.