### PR TITLE
Make version string return full string with vcs

### DIFF
--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -17,7 +17,7 @@ import sys
 
 from stestr import version
 
-__version__ = version.version_info.version_string()
+__version__ = version.version_info.version_string_with_vcs()
 
 
 class StestrCLI(object):


### PR DESCRIPTION
This commit makes the version string full with vcs. It is used for
--version option. Sometimes I want to know more detailed version to know
the exact version what I'm using.