### PR TITLE
Add combine option to stestr run

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -146,6 +146,20 @@ selection options to do this, for example::
 This will list all the tests which will be run by stestr using that combination
 of arguments.
 
+Combining Test Results
+----------------------
+There is sometimes a use case for running a single test suite split between
+multiple invocations of the stestr run command. For example, running a subset
+of tests with a different concurrency. In these cases you can use the
+``--combine`` flag on ``stestr run```. When this flag is specified stestr will
+append the subunit stream from the test run into the most recent entry in the
+repository.
+
+Alternatively, you can manually load the test results from a subunit stream into
+an existing test result in the repository using the ``--id``/``-i`` flag on
+the ``stestr load`` command. This will append the results from the input subunit
+stream to the specified id.
+
 
 Running previously failed tests
 '''''''''''''''''''''''''''''''

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -80,7 +80,7 @@ def run(arguments):
 
 
 def load(arguments, in_streams=None, partial=False, subunit_out=False,
-         repo_type=None, repo_url=None):
+         repo_type=None, repo_url=None, run_id=None):
     args = arguments[0]
     streams = arguments[1]
     if args:
@@ -130,6 +130,7 @@ def load(arguments, in_streams=None, partial=False, subunit_out=False,
     _run_id = None
     if args:
         _run_id = getattr(args, 'id')
+    _run_id = _run_id or run_id
     if not _run_id:
         inserter = repo.get_inserter(partial=partial_stream)
     else:


### PR DESCRIPTION
This commit adds a cli flag to stestr run to append the results of the
run to the latest run in the repository. This is useful if you're
splitting the execution of a test suite over multiple invocations of
stestr run.