### PR TITLE
Enable coverage with tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = True
+source = stestr
+omit = stestr/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__
 doc/build/
 releasenotes/build/
 .stestr.sqlite
+.coverage*
+!.coveragerc
+cover/

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,11 @@ commands =
 [testenv:venv]
 commands = {posargs}
 
+[testenv:cover]
+commands =
+    coverage run stestr/cli.py run {posargs}
+    coverage html -d cover
+
 [testenv:docs]
 commands = python setup.py build_sphinx
 


### PR DESCRIPTION
This commit enables to get coverage with tox. We probably should care
about unit test coverage data of stestr a bit :)