### PR TITLE
Add cover to tox envlist to enable coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ cache:
     - $HOME/.cache/pip
 install: pip install -U tox coveralls
 language: python
-script: tox
+script:
+  - tox
+  - tox -e cover
 after_success: coveralls
 notifications:
   email: false


### PR DESCRIPTION
This commit adds 'cover' task to the tox envlist to enable coveralls
job.