### PR TITLE
Add codeclimate and pypi version badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Slim/Super Test Repository
 .. image:: https://coveralls.io/repos/github/mtreinish/stestr/badge.svg?branch=master
     :target: https://coveralls.io/github/mtreinish/stestr?branch=master
 
+.. image:: https://img.shields.io/pypi/v/stestr.svg
+    :target: https://pypi.python.org/pypi/stestr
 
 You can see the full rendered docs at: http://stestr.readthedocs.io/en/latest/
 


### PR DESCRIPTION
This commit adds two badges of codeclimate[1] and pypi version[2]. This
might be useful for healthy code and to know the latest version of
stestr.

[1] https://codeclimate.com/github/mtreinish/stestr
[2] https://pypi.python.org/pypi/stestr