### PR TITLE
Cleanup error handling for missing test-path or config file

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -114,8 +114,12 @@ def run(arguments):
         repo = util.get_repo_open(args.repo_type, args.repo_url)
     # If a repo is not found, and there a testr config exists just create it
     except repository.RepositoryNotFound:
-        if not os.path.isfile(args.config):
-            raise
+        if not os.path.isfile(args.config) and not args.test_path:
+            msg = ("No config file found and --test-path not specified. "
+                   "Either create or specify a .stestr.conf or use "
+                   "--test-path ")
+            print(msg)
+            exit(1)
         repo = util.get_repo_initialise(args.repo_type, args.repo_url)
     if args.no_discover:
         ids = args.no_discover

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -53,9 +53,10 @@ class TestrConf(object):
         elif self.parser.has_option('DEFAULT', 'test_path'):
             test_path = self.parser.get('DEFAULT', 'test_path')
         else:
-            print("no test_path can be found in either the command line "
-                  "options nor in config file {0}.  Are you running stestr "
-                  "from an unexpected location?".format(self.config_file))
+            print("No test_path can be found in either the command line "
+                  "options nor in the specified config file {0}.  Please "
+                  "specify a test path either in the config file or via the "
+                  "--test-path argument".format(self.config_file))
             sys.exit(1)
         top_dir = './'
         if options.top_dir:


### PR DESCRIPTION
This commit cleans up the error handling for when stestr run is called
without a repository and no config file or test-path arg is specified.
This is very common for new users to go to a directory with tests and
run 'stestr run' not having read the README or manual. Previously if
this was done you'd be greated by a repository not found traceback which
is hardly helpful. This cleans it up so a message prints explaing what's
missing and exits with an error code. As commit also cleans up the
wording for the error message when the same mistake is made with a
pre-existing repository.