### PR TITLE
Cleanup output from test listing fixture

### DIFF
--- a/stestr/output.py
+++ b/stestr/output.py
@@ -93,20 +93,6 @@ def make_result(get_id, output=sys.stdout):
     return result, summary
 
 
-def output_values(values, output=sys.stdout):
-    """Display key value pairs.
-
-    :param values: A list of tuples for key value pairs. Each tuple in the list
-        is of the form (key, value).
-    :param output: The output file object to write the list to. By default this
-        is sys.stdout
-    """
-    outputs = []
-    for label, value in values:
-        outputs.append('%s=%s' % (label, value))
-    output.write(six.text_type('%s\n' % ', '.join(outputs)))
-
-
 def output_summary(successful, tests, tests_delta, time, time_delta, values,
                    output=sys.stdout):
     """Display a summary view for the test run.


### PR DESCRIPTION
The test listing fixture had some leftover output straight from testr
which can be confusing. First is it prints the subprocess commands that
were being run, which is unecessary and confusing if you don't know what
is going in on internally. Secondly when it encounters an import it
raises an unhandled exception to crash. This commit fixes this by
printing out a more detailed view of what happened with an explanation.
Also a leftover failure condition from testrepository was removed
because it can never be tripped in stestr.