### PR TITLE
Get coverage only one time in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.6"
+      env: TOXENV=cover
     - python: "3.5"
       env: TOXENV=pep8
     - python: "2.7"
@@ -19,7 +21,6 @@ install: pip install -U tox coveralls
 language: python
 script:
   - tox
-  - tox -e cover
-after_success: coveralls
+after_success: .travis/coveralls.sh
 notifications:
   email: false

--- a/.travis/coveralls.sh
+++ b/.travis/coveralls.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$TOXENV" = "cover" ]; then
+    coverall
+fi


### PR DESCRIPTION
This commit makes to get coverage only one time in travis-ci. We don't
need to get coverages for every python environment and pep8 task.

Fixes #59