### PR TITLE
Add a concurrency option to the manual scheduler

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -307,7 +307,26 @@ example::
       - regex 3
 
 would create 2 workers. The first would run all tests that match regex 1, and
-the second would run all tests that match regex 2 or regex 3.
+the second would run all tests that match regex 2 or regex 3. In addition if
+you need to mix manual scheduling and the standard scheduling mechanisms you
+can accomplish this with the ``concurrency`` field on a worker in the yaml.
+For example, building on the previous example::
+
+    - worker:
+      - regex 1
+
+    - worker:
+      - regex 2
+      - regex 3
+
+    - worker:
+      - regex 4
+      concurrency: 3
+
+In this case the tests that match regex 4 will be run against 3 workers and the
+tests will be partitioned across those workers with the normal scheduler. This
+includes respecting the other scheduler options, like ``group_regex`` or
+``--random``.
 
 There is also an option on ``stestr run``, ``--random``/``-r`` to randomize the
 order of tests as they are passed to the workers. This is useful in certain

--- a/stestr/test_listing_fixture.py
+++ b/stestr/test_listing_fixture.py
@@ -227,7 +227,8 @@ class TestListingFixture(fixtures.Fixture):
             if hasattr(self.options, 'randomize'):
                 randomize = self.options.randomize
             test_id_groups = scheduler.generate_worker_partitions(
-                test_ids, self.worker_path, randomize)
+                test_ids, self.worker_path, self.repository,
+                self._group_callback, randomize)
         # If we have multiple workers partition the tests and recursively
         # create single worker TestListingFixtures for each worker
         else:

--- a/stestr/tests/test_scheduler.py
+++ b/stestr/tests/test_scheduler.py
@@ -169,3 +169,37 @@ class TestScheduler(base.TestCase):
             ['test_a', 'test_b', 'your_test'],
         ]
         self.assertEqual(expected_grouping, groups)
+
+    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    def test_generate_worker_partitions_with_count(self):
+        test_ids = ['test_a', 'test_b', 'your_test', 'a_thing1', 'a_thing2']
+        fake_worker_yaml = [
+            {'worker': ['test_']},
+            {'worker': ['test']},
+            {'worker': ['a_thing'], 'concurrency': 2},
+        ]
+        with mock.patch('yaml.load', return_value=fake_worker_yaml):
+            groups = scheduler.generate_worker_partitions(test_ids, 'fakepath')
+        expected_grouping = [
+            ['test_a', 'test_b'],
+            ['test_a', 'test_b', 'your_test'],
+            ['a_thing1'],
+            ['a_thing2'],
+        ]
+        for worker in expected_grouping:
+            self.assertIn(worker, groups)
+
+    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    def test_generate_worker_partitions_with_count_1(self):
+        test_ids = ['test_a', 'test_b', 'your_test']
+        fake_worker_yaml = [
+            {'worker': ['test_']},
+            {'worker': ['test'], 'count': 1},
+        ]
+        with mock.patch('yaml.load', return_value=fake_worker_yaml):
+            groups = scheduler.generate_worker_partitions(test_ids, 'fakepath')
+        expected_grouping = [
+            ['test_a', 'test_b'],
+            ['test_a', 'test_b', 'your_test'],
+        ]
+        self.assertEqual(expected_grouping, groups)


### PR DESCRIPTION
This commit adds a new option in the manual scheduler yaml syntax. There
are certain situations where you want to treat a subset of tests being
manually scheduled like the default case with the standard test
scheduling mechanisms. To enable doing this a 'concurrency' field can be
used on a worker, and tests on those workers will be scheduled like
normal across the number of workers specified.