### PR TITLE
Rename the test_listing_fixture to test_processor

### DIFF
--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -16,7 +16,7 @@ import sys
 from six.moves import configparser
 
 from stestr.repository import util
-from stestr import test_listing_fixture
+from stestr import test_processor
 
 
 class TestrConf(object):
@@ -39,18 +39,21 @@ class TestrConf(object):
                         concurrency=0, blacklist_file=None,
                         whitelist_file=None, black_regex=None,
                         randomize=False):
-        """Get a test_listing_fixture.TestListingFixture for this config file
+        """Get a test_processor.TestProcessorFixture for this config file
 
         Any parameters about running tests will be used for initialize the
         output fixture so the settings are correct when that fixture is used
         to run tests. Parameters will take precedence over values in the config
         file.
 
+        :param options: A argparse Namespace object of the cli options that
+            were used in the invocation of the original CLI command that
+            needs a TestProcessorFixture
         :param list test_ids: an optional list of test_ids to use when running
             tests
         :param list regexes: an optional list of regex strings to use for
             filtering the tests to run. See the test_filters parameter in
-            TestListingFixture to see how this is used.
+            TestProcessorFixture to see how this is used.
         :param str test_path: Set the test path to use for unittest discovery.
             If both this and the corresponding config file option are set, this
             value will be used.
@@ -79,9 +82,9 @@ class TestrConf(object):
          :param bool randomize: Randomize the test order after they are
             partitioned into separate workers
 
-        :returns: a TestListingFixture object for the specified config file and
-            any arguments passed into this function
-        :rtype: test_listing_fixture.TestListingFixture
+        :returns: a TestProcessorFixture object for the specified config file
+            and any arguments passed into this function
+        :rtype: test_processor.TestProcessorFixture
         """
 
         if not test_path and self.parser.has_option('DEFAULT', 'test_path'):
@@ -117,7 +120,7 @@ class TestrConf(object):
 
         # Handle the results repository
         repository = util.get_repo_open(repo_type, repo_url)
-        return test_listing_fixture.TestListingFixture(
+        return test_processor.TestProcessorFixture(
             test_ids, command, listopt, idoption, repository,
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -27,10 +27,10 @@ from stestr import selection
 from stestr import testlist
 
 
-class TestListingFixture(fixtures.Fixture):
+class TestProcessorFixture(fixtures.Fixture):
     """Write a temporary file to disk with test ids in it.
 
-    The TestListingFixture is used to handle the lifecycle of running
+    The TestProcessorFixture is used to handle the lifecycle of running
     the subunit.run commands. A fixture is used for this class to handle
     the temporary list files creation.
 
@@ -81,7 +81,7 @@ class TestListingFixture(fixtures.Fixture):
                  test_filters=None, group_callback=None, serial=False,
                  worker_path=None, concurrency=0, blacklist_file=None,
                  black_regex=None, whitelist_file=None, randomize=False):
-        """Create a TestListingFixture."""
+        """Create a TestProcessorFixture."""
 
         self.test_ids = test_ids
         self.template = cmd_template
@@ -103,7 +103,7 @@ class TestListingFixture(fixtures.Fixture):
         self.randomize = randomize
 
     def setUp(self):
-        super(TestListingFixture, self).setUp()
+        super(TestProcessorFixture, self).setUp()
         variable_regex = '\$(IDOPTION|IDFILE|IDLIST|LISTOPT)'
         variables = {}
         list_variables = {'LISTOPT': self.listopt}
@@ -243,7 +243,7 @@ class TestListingFixture(fixtures.Fixture):
                 test_ids, self.worker_path, self.repository,
                 self._group_callback, self.randomize)
         # If we have multiple workers partition the tests and recursively
-        # create single worker TestListingFixtures for each worker
+        # create single worker TestProcessorFixtures for each worker
         else:
             test_id_groups = scheduler.partition_tests(test_ids,
                                                        self.concurrency,
@@ -254,8 +254,9 @@ class TestListingFixture(fixtures.Fixture):
                 # No tests in this partition
                 continue
             fixture = self.useFixture(
-                TestListingFixture(test_ids,
-                                   self.template, self.listopt, self.idoption,
-                                   self.repository, parallel=False))
+                TestProcessorFixture(test_ids,
+                                     self.template, self.listopt,
+                                     self.idoption, self.repository,
+                                     parallel=False))
             result.extend(fixture.run_tests())
         return result

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -25,9 +25,9 @@ class TestTestrConf(base.TestCase):
         self._testr_conf.parser = mock.Mock()
 
     @mock.patch.object(config_file.util, 'get_repo_open')
-    @mock.patch.object(config_file.test_listing_fixture, 'TestListingFixture')
+    @mock.patch.object(config_file.test_processor, 'TestProcessorFixture')
     @mock.patch.object(config_file, 'sys')
-    def _check_get_run_command(self, mock_sys, mock_TestListingFixture,
+    def _check_get_run_command(self, mock_sys, mock_TestProcessorFixture,
                                mock_get_repo_open, platform='win32',
                                expected_python='python'):
         mock_sys.platform = platform
@@ -36,14 +36,14 @@ class TestTestrConf(base.TestCase):
                                                    top_dir='fake_top_dir',
                                                    group_regex='.*')
 
-        self.assertEqual(mock_TestListingFixture.return_value, fixture)
+        self.assertEqual(mock_TestProcessorFixture.return_value, fixture)
         mock_get_repo_open.assert_called_once_with('file',
                                                    None)
         command = "%s -m subunit.run discover -t %s %s $LISTOPT $IDOPTION" % (
             expected_python, 'fake_top_dir', 'fake_test_path')
-        # Ensure TestListingFixture is created with defaults except for where
+        # Ensure TestProcessorFixture is created with defaults except for where
         # we specfied and with the correct python.
-        mock_TestListingFixture.assert_called_once_with(
+        mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
             mock_get_repo_open.return_value, black_regex=None,
             blacklist_file=None, concurrency=0, group_callback=mock.ANY,

--- a/stestr/tests/test_test_processor.py
+++ b/stestr/tests/test_test_processor.py
@@ -14,21 +14,21 @@ import subprocess
 
 import mock
 
-from stestr import test_listing_fixture
+from stestr import test_processor
 from stestr.tests import base
 
 
-class TestTestListingFixture(base.TestCase):
+class TestTestProcessorFixture(base.TestCase):
 
     def setUp(self):
-        super(TestTestListingFixture, self).setUp()
-        self._fixture = test_listing_fixture.TestListingFixture(
+        super(TestTestProcessorFixture, self).setUp()
+        self._fixture = test_processor.TestProcessorFixture(
             mock.sentinel.test_ids, mock.sentinel.options,
             mock.sentinel.cmd_template, mock.sentinel.listopt,
             mock.sentinel.idoption, mock.sentinel.repository)
 
     @mock.patch.object(subprocess, 'Popen')
-    @mock.patch.object(test_listing_fixture, 'sys')
+    @mock.patch.object(test_processor, 'sys')
     def _check_start_process(self, mock_sys, mock_Popen, platform='win32',
                              expected_fn=None):
         mock_sys.platform = platform


### PR DESCRIPTION
The name test_listing_fixture was a bit confusing. It was a hold over
from test_repository that was never renamed. Even in testrepository the
function of the module is much more than simply listing tests. It's
where all the test workers are launched. While if you look at the
internals of the module the life of the fixture is around the temporary
test list files it creates. But, this name is confusing for people not
super familiar with the internals.

To try and clear up any potential confusion here this commit renames it
to the more generic 'test_processor' (and the Fixture class inside).
This hopefully makes it more clear that the role of the module is around
processing the tests, and more than just listing things.

Closes Issue #21