### PR TITLE
Add python interface for commands

### DIFF
--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -15,8 +15,24 @@
 from stestr.repository import util
 
 
-def run(args):
-    util.get_repo_initialise(args[0].repo_type, args[0].repo_url)
+def run(arguments):
+    args = arguments[0]
+    init(args.repo_type, args.repo_url)
+
+
+def init(repo_type='file', repo_url=None):
+    """Initialize a new repository
+
+    Note this function depends on the cwd for the repository if `repo_type` is
+    set to file and `repo_url` is not specified it will use the repository
+    located at CWD/.stestr
+
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    """
+
+    util.get_repo_initialise(repo_type, repo_url)
 
 
 def set_cli_opts(parser):

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -40,16 +40,32 @@ def set_cli_opts(parser):
 
 def run(arguments):
     args = arguments[0]
-    repo = util.get_repo_open(args.repo_type, args.repo_url)
+    return last(repo_type=args.repo_type, repo_url=args.repo_url,
+                subunit=args.subunit)
+
+
+def last(repo_type='file', repo_url=None, subunit=False):
+    """Show the last run loaded into a a repository
+
+    Note this function depends on the cwd for the repository if `repo_type` is
+    set to file and `repo_url` is not specified it will use the repository
+    located at CWD/.stestr
+
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param bool subunit: Show output as a subunit stream.
+    """
+    repo = util.get_repo_open(repo_type, repo_url)
     latest_run = repo.get_latest_run()
-    if args.subunit:
+    if subunit:
         stream = latest_run.get_subunit_stream()
         output.output_stream(stream)
         # Exits 0 if we successfully wrote the stream.
         return 0
     case = latest_run.get_test()
     try:
-        if args.repo_type == 'file':
+        if repo_type == 'file':
             previous_run = repo.get_test_run(repo.latest_id() - 1)
         # TODO(mtreinish): add a repository api to get the previous_run to
         # unify this logic

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -45,16 +45,59 @@ def set_cli_opts(parser):
                         ' white selection, which by default is everything.')
 
 
-def run(args):
-    _args = args[0]
+def run(arguments):
+    args = arguments[0]
+    filters = arguments[1]
+    return list_command(config=args.config, repo_type=args.repo_type,
+                        repo_url=args.repo_url, group_regex=args.group_regex,
+                        blacklist_file=args.blacklist_file,
+                        whitelist_file=args.whitelist_file,
+                        black_regex=args.black_regex,
+                        filters=filters)
+
+
+def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
+                 test_path=None, top_dir=None, group_regex=None,
+                 blacklist_file=None, whitelist_file=None, black_regex=None,
+                 filters=None):
+    """Print a list of test_ids for a project
+
+    This function will print the test_ids for tests in a project. You can
+    filter the output just like with the run command to see exactly what
+    will be run.
+
+    :param str config: The path to the stestr config file. Must be a string.
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param str test_path: Set the test path to use for unittest discovery.
+        If both this and the corresponding config file option are set, this
+        value will be used.
+    :param str top_dir: The top dir to use for unittest discovery. This takes
+        precedence over the value in the config file. (if one is present in
+        the config file)
+    :param str group_regex: Set a group regex to use for grouping tests
+        together in the stestr scheduler. If both this and the corresponding
+        config file option are set this value will be used.
+    :param str blacklist_file: Path to a blacklist file, this file contains a
+        separate regex exclude on each newline.
+    :param str whitelist_file: Path to a whitelist file, this file contains a
+        separate regex on each newline.
+    :param str black_regex: Test rejection regex. If a test cases name matches
+        on re.search() operation, it will be removed from the final test list.
+    :param list filters: A list of string regex filters to initially apply on
+        the test list. Tests that match any of the regexes will be used.
+        (assuming any other filtering specified also uses it)
+    """
     ids = None
-    filters = None
-    if args[1]:
-        filters = args[1]
-    conf = config_file.TestrConf(_args.config)
-    cmd = conf.get_run_command(_args, ids, filters)
-    not_filtered = filters is None and _args.blacklist_file is None\
-        and _args.whitelist_file is None and _args.black_regex is None
+    conf = config_file.TestrConf(config)
+    cmd = conf.get_run_command(
+        regexes=filters, repo_type=repo_type,
+        repo_url=repo_url, group_regex=group_regex,
+        blacklist_file=blacklist_file, whitelist_file=whitelist_file,
+        black_regex=black_regex)
+    not_filtered = filters is None and blacklist_file is None\
+        and whitelist_file is None and black_regex is None
     try:
         cmd.setUp()
         # List tests if the fixture has not already needed to to filter.

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -54,27 +54,6 @@ def get_cli_help():
     return help_str
 
 
-class InputToStreamResult(object):
-    """Generate Stream events from stdin.
-
-    Really a UI responsibility?
-    """
-
-    def __init__(self, stream):
-        self.source = stream
-        self.stop = False
-
-    def run(self, result):
-        while True:
-            if self.stop:
-                return
-            char = self.source.read(1)
-            if not char:
-                return
-            if char == b'a':
-                result.status(test_id='stdin', test_status='fail')
-
-
 def run(arguments):
     load(arguments)
 

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -50,8 +50,22 @@ def format_times(times):
     return times
 
 
-def run(args):
-    repo = util.get_repo_open(args[0].repo_type, args[0].repo_url)
+def run(arguments):
+    args = arguments[0]
+    return slowest(repo_type=args.repo_type, repo_url=args.repo_url,
+                   show_all=args.all)
+
+
+def slowest(repo_type='file', repo_url=None, show_all=False):
+    """Print the slowest times from the last run in the repository
+
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param bool show_all: Show timing for all tests.
+    """
+
+    repo = util.get_repo_open(repo_type, repo_url)
     try:
         latest_id = repo.latest_id()
     except KeyError:
@@ -62,7 +76,7 @@ def run(args):
     known_times.sort(key=itemgetter(1), reverse=True)
     if len(known_times) > 0:
         # By default show 10 rows
-        if not args[0].all:
+        if not show_all:
             known_times = known_times[:10]
         known_times = format_times(known_times)
         header = ('Test id', 'Runtime (s)')

--- a/stestr/commands/stats.py
+++ b/stestr/commands/stats.py
@@ -25,7 +25,18 @@ def set_cli_opts(parser):
     pass
 
 
-def run(args):
-    repo = util.get_repo_open(args[0].repo_type, args[0].repo_url)
+def run(arguments):
+    args = arguments[0]
+    return stats(repo_type=args.repo_type, repo_url=args.repo_url)
+
+
+def stats(repo_type='file', repo_url=None):
+    """Print repo stats
+
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    """
+    repo = util.get_repo_open(repo_type, repo_url)
     sys.stdout.write('%s=%s\n' % ('runs', repo.count()))
     return 0

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -31,24 +31,24 @@ class TestTestrConf(base.TestCase):
                                mock_get_repo_open, platform='win32',
                                expected_python='python'):
         mock_sys.platform = platform
-        mock_options = mock.Mock()
-        mock_options.test_path = 'fake_test_path'
-        mock_options.top_dir = 'fake_top_dir'
-        mock_options.group_regex = '.*'
 
-        fixture = self._testr_conf.get_run_command(mock_options,
-                                                   mock.sentinel.test_ids,
-                                                   mock.sentinel.regexes)
+        fixture = self._testr_conf.get_run_command(test_path='fake_test_path',
+                                                   top_dir='fake_top_dir',
+                                                   group_regex='.*')
 
         self.assertEqual(mock_TestListingFixture.return_value, fixture)
-        mock_get_repo_open.assert_called_once_with(mock_options.repo_type,
-                                                   mock_options.repo_url)
+        mock_get_repo_open.assert_called_once_with('file',
+                                                   None)
         command = "%s -m subunit.run discover -t %s %s $LISTOPT $IDOPTION" % (
-            expected_python, mock_options.top_dir, mock_options.test_path)
+            expected_python, 'fake_top_dir', 'fake_test_path')
+        # Ensure TestListingFixture is created with defaults except for where
+        # we specfied and with the correct python.
         mock_TestListingFixture.assert_called_once_with(
-            mock.sentinel.test_ids, mock_options, command, "--list",
-            "--load-list $IDFILE", mock_get_repo_open.return_value,
-            test_filters=mock.sentinel.regexes, group_callback=mock.ANY)
+            None, command, "--list", "--load-list $IDFILE",
+            mock_get_repo_open.return_value, black_regex=None,
+            blacklist_file=None, concurrency=0, group_callback=mock.ANY,
+            test_filters=None, randomize=False, serial=False,
+            whitelist_file=None, worker_path=None)
 
     def test_get_run_command_linux(self):
         self._check_get_run_command(platform='linux2',


### PR DESCRIPTION
This commit adds a real api for running the stestr commands. Instead of just having a magic run() function that takes in an tuple of a argparse Namespace and a list of undefined arguments this migrates all the real work into a function that has properly defined kwargs. The run() command is then relegated to just convert the Namespace into a dict and pass the arguments into that real function. This enables external programs to just call the new functions with defined args and run commands exactly like on the cli, but with a defined python interface. It makes everything a lot easier for python consumption. The tradeoff here though is that everything is bit more verbose, but that's the cost of being explicit with a defined interface.

As a side effect of this change instead of passing that Namespace object around between all the lower layers real interfaces have to be defined for all the functions. This means a ton of new kwargs, but again this is better in the long run because it means we have defined interfaces for all the functions.

Closes Issue #8