### PR TITLE
Fix stestr run --until-failure with subunit output

### DIFF
--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -93,6 +93,13 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run --subunit passing', 0,
                            subunit=True)
 
+    def test_until_failure_fails(self):
+        self.assertRunExit('stestr run --until-failure', 1)
+
+    def test_until_failure_with_subunit_fails(self):
+        self.assertRunExit('stestr run --until-failure --subunit', 1,
+                           subunit=True)
+
     def test_list(self):
         self.assertRunExit('stestr list', 0)
 


### PR DESCRIPTION
The --subunit flag on stestr run, load, etc always returns 0. This is
done primarily to ensure that subunit processing can happen without
issue, especially from inside a python caller. (there is also an implicit
assumption that if you emit subunit whatever consumes that will check
for the failure condition and handle that itself) This has a side effect
for the --until-failure flag on stestr run which will never exit if
--subunit is used because there is never a failure condition detected
because subunit output always returns 0. This commit fixes this by
checking the repository directly for failure if --subunit and
--until-failure are used together.

Closes Issue #68