### PR TITLE
Fix stestr --test-path argument for stestr run and list

### DIFF
--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -86,7 +86,7 @@ class TestrConf(object):
 
         if not test_path and self.parser.has_option('DEFAULT', 'test_path'):
             test_path = self.parser.get('DEFAULT', 'test_path')
-        else:
+        elif not test_path:
             print("No test_path can be found in either the command line "
                   "options nor in the specified config file {0}.  Please "
                   "specify a test path either in the config file or via the "


### PR DESCRIPTION
This commit fixes a small bug in the recent python api change that
causes the --test-path argument to not work. The if condition for
determining if a test_path is not set in either the config file or the
cli was mistakenly assuming if it was set on the cli was the same as not
being set. This commit fixes it by explictly checking if it's not set.