### PR TITLE
Add API docs for the commands

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -21,6 +21,57 @@ Repository
 Commands
 --------
 
+These modules are used for the operation of all the various subcommands in
+stestr. As of the 1.0.0 release each of these commands should be considered
+a stable interface that can be relied on externally.
+
+Each command module conforms to a basic format that is used by ``stestr.cli``
+to load each command. The basic structure for these modules is the following
+three functions::
+
+  def get_cli_help():
+      """This function returns a string that is used for the subcommand help"""
+      help_str = "A descriptive help string about the command"
+      return help_str
+
+  def get_cli_opts(parser):
+      """This function takes a parser and any subcommand arguments are defined
+         here"""
+      parser.add_argument(...)
+
+  def run(arguments):
+      """This function actually runs the command. It takes in a tuple arguments
+         which the first element is the argparse Namespace object with the
+         arguments from the parser. The second element is a list of unknown
+         arguments from the CLI. The expectation of the run method is that it
+         will process the arguments and call another function that does the
+         real work. The return value is expected to be an int and is used for
+         the exit code (assuming the function doesn't call sys.exit() on it's
+         own)"""
+      args = arguments[0]
+      unknown_args = arguments[1]
+      return call_foo()
+
+The command module will not work if all 3 of these function are not defined.
+However, to make the commands externally consumable each module also contains
+another public function which performs the real work for the command. Each one
+of these functions has a defined stable Python API signature with args and
+kwargs so that people can easily call the functions from other python programs.
+This function is what can be expected to be used outside of stestr as the stable
+interface.
+
+.. toctree::
+   :maxdepth: 2
+
+   api/commands/failing
+   api/commands/init
+   api/commands/last
+   api/commands/list
+   api/commands/load
+   api/commands/run
+   api/commands/slowest
+
+
 Internal APIs
 -------------
 

--- a/doc/source/api/commands/failing.rst
+++ b/doc/source/api/commands/failing.rst
@@ -1,0 +1,7 @@
+.. _failing_command:
+
+stestr failing Command
+======================
+
+.. automodule:: stestr.commands.failing
+   :members:

--- a/doc/source/api/commands/init.rst
+++ b/doc/source/api/commands/init.rst
@@ -1,0 +1,7 @@
+.. _init_command:
+
+stestr init Command
+===================
+
+.. automodule:: stestr.commands.init
+   :members:

--- a/doc/source/api/commands/last.rst
+++ b/doc/source/api/commands/last.rst
@@ -1,0 +1,7 @@
+.. _last_command:
+
+stestr last Command
+===================
+
+.. automodule:: stestr.commands.last
+   :members:

--- a/doc/source/api/commands/list.rst
+++ b/doc/source/api/commands/list.rst
@@ -1,0 +1,7 @@
+.. _list_command:
+
+stestr list Command
+===================
+
+.. automodule:: stestr.commands.list
+   :members:

--- a/doc/source/api/commands/load.rst
+++ b/doc/source/api/commands/load.rst
@@ -1,0 +1,7 @@
+.. _load_command:
+
+stestr load Command
+===================
+
+.. automodule:: stestr.commands.load
+   :members:

--- a/doc/source/api/commands/run.rst
+++ b/doc/source/api/commands/run.rst
@@ -1,0 +1,7 @@
+.. _run_command:
+
+stestr run Command
+==================
+
+.. automodule:: stestr.commands.run
+   :members:

--- a/doc/source/api/commands/slowest.rst
+++ b/doc/source/api/commands/slowest.rst
@@ -1,0 +1,7 @@
+.. _slowest_command:
+
+stestr slowest Command
+======================
+
+.. automodule:: stestr.commands.slowest
+   :members:

--- a/doc/source/internal_arch.rst
+++ b/doc/source/internal_arch.rst
@@ -58,15 +58,16 @@ run(arguments)
 This is where the real work for the command is performed. This is the function
 that is called when the command is executed. This function is called being
 wrapped by sys.exit() so an integer return is expected that will be used
-for the command's return code.
-
-.. todo::
-  Define an API for the arguments. Right now it's a tuple with a
-  argparse.Namespace object and a list, but this isn't set in stone.
+for the command's return code. The arguments input arg is a tuple, the first
+element is the argparse.Namespace object from the parsed CLI options and the
+second element is a list of unknown arguments from the CLI. The expectation
+is that this function will call a separate function with a real python API
+that does all the real work. (which is the public python interface for the
+command)
 
 
 Operations for Running Tests
---------------------------
+----------------------------
 
 The basic flow when stestr run is called at a high level is fairly straight
 forward. In the default case when run is called the first operation performed

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -64,7 +64,12 @@ def run(arguments):
 
 
 def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False):
-    """Return the failing tests from the most recent run in the repository
+    """Print the failing tests from the most recent run in the repository
+
+    This function will print to STDOUT whether there are any tests that failed
+    in the last run. It optionally will print the test_ids for the failing
+    tests if ``list_tests`` is true. If ``subunit`` is true a subunit stream
+    with just the failed tests will be printed to STDOUT.
 
     Note this function depends on the cwd for the repository if `repo_type` is
     set to file and `repo_url` is not specified it will use the repository
@@ -76,6 +81,9 @@ def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False):
     :param bool list_test: Show only a list of failing tests.
     :param bool subunit: Show output as a subunit stream.
 
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
     if repo_type not in ['file', 'sql']:
         print('Repository type %s is not a type' % repo_type)

--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -23,6 +23,9 @@ def run(arguments):
 def init(repo_type='file', repo_url=None):
     """Initialize a new repository
 
+    This function will create initialize a new repostiory if one does not
+    exist. If one exists the command will fail.
+
     Note this function depends on the cwd for the repository if `repo_type` is
     set to file and `repo_url` is not specified it will use the repository
     located at CWD/.stestr
@@ -30,6 +33,10 @@ def init(repo_type='file', repo_url=None):
     :param str repo_type: This is the type of repository to use. Valid choices
         are 'file' and 'sql'.
     :param str repo_url: The url of the repository to use.
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
 
     util.get_repo_initialise(repo_type, repo_url)

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -47,6 +47,10 @@ def run(arguments):
 def last(repo_type='file', repo_url=None, subunit=False):
     """Show the last run loaded into a a repository
 
+    This function will print the results from the last run in the repository
+    to STDOUT. It can optionally print the subunit stream for the last run
+    to STDOUT if the ``subunit`` option is set to true.
+
     Note this function depends on the cwd for the repository if `repo_type` is
     set to file and `repo_url` is not specified it will use the repository
     located at CWD/.stestr
@@ -55,6 +59,10 @@ def last(repo_type='file', repo_url=None, subunit=False):
         are 'file' and 'sql'.
     :param str repo_url: The url of the repository to use.
     :param bool subunit: Show output as a subunit stream.
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
     repo = util.get_repo_open(repo_type, repo_url)
     latest_run = repo.get_latest_run()

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -66,6 +66,11 @@ def load(force_init=False, in_streams=None,
          run_id=None, streams=None):
     """Load subunit streams into a repository
 
+    This function will load subunit streams into the repository. It will
+    output to STDOUT the results from the input stream. Internally this is
+    used by the run command to both output the results as well as store the
+    result in the repository.
+
     :param bool force_init: Initialize the specifiedrepository if it hasn't
         been created.
     :param list in_streams: A list of file objects that will be saved into the
@@ -77,6 +82,10 @@ def load(force_init=False, in_streams=None,
     :param str repo_url: The url of the repository to use.
     :param run_id: The optional run id to save the subunit stream to.
     :param list streams: A list of file paths to read for the input streams.
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
 
     try:

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -122,7 +122,8 @@ def run_command(config='.stestr.conf', repo_type='file',
 
     This function implements the run command. It will run the tests specified
     in the parameters based on the provided config file and/or arguments
-    specified in the way specified by the arguments.
+    specified in the way specified by the arguments. The results will be
+    printed to STDOUT and loaded into the repository.
 
     :param str config: The path to the stestr config file. Must be a string.
     :param str repo_type: This is the type of repository to use. Valid choices
@@ -168,6 +169,10 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param list filters: A list of string regex filters to initially apply on
         the test list. Tests that match any of the regexes will be used.
         (assuming any other filtering specified also uses it)
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
     try:
         repo = util.get_repo_open(repo_type, repo_url)

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -59,10 +59,18 @@ def run(arguments):
 def slowest(repo_type='file', repo_url=None, show_all=False):
     """Print the slowest times from the last run in the repository
 
+    This function will print to STDOUT the 10 slowests tests in the last run.
+    Optionally, using the ``show_all`` argument, it will print all the tests,
+    instead of just 10. sorted by time.
+
     :param str repo_type: This is the type of repository to use. Valid choices
         are 'file' and 'sql'.
     :param str repo_url: The url of the repository to use.
     :param bool show_all: Show timing for all tests.
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
     """
 
     repo = util.get_repo_open(repo_type, repo_url)


### PR DESCRIPTION
This commit adds api documentation for the commands modules in
preparation for the next release. These modules wil lbe considered a
stable interface moving forward, so we want to have documentation for
their use.