### PR TITLE
Add stdout param

### DIFF
--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -43,7 +43,7 @@ def _show_subunit(run):
     return 0
 
 
-def _make_result(repo, list_tests=False):
+def _make_result(repo, list_tests=False, stdout=sys.stdout):
     if list_tests:
         list_result = testtools.StreamSummary()
         return list_result, list_result
@@ -52,7 +52,7 @@ def _make_result(repo, list_tests=False):
             return repo.get_latest_run().get_id()
 
         output_result = results.CLITestResult(_get_id,
-                                              sys.stdout, None)
+                                              stdout, None)
         summary_result = output_result.get_summary()
         return output_result, summary_result
 
@@ -63,7 +63,8 @@ def run(arguments):
                    list_tests=args.list, subunit=args.subunit)
 
 
-def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False):
+def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False,
+            stdout=sys.stdout):
     """Print the failing tests from the most recent run in the repository
 
     This function will print to STDOUT whether there are any tests that failed
@@ -80,13 +81,15 @@ def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False):
     :param str repo_url: The url of the repository to use.
     :param bool list_test: Show only a list of failing tests.
     :param bool subunit: Show output as a subunit stream.
+    :param file stdout: The output file to write all output to. By default
+        this is sys.stdout
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
     :rtype: int
     """
     if repo_type not in ['file', 'sql']:
-        print('Repository type %s is not a type' % repo_type)
+        stdout.write('Repository type %s is not a type' % repo_type)
         return 1
 
     repo = util.get_repo_open(repo_type, repo_url)
@@ -109,5 +112,5 @@ def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False):
     if list_tests:
         failing_tests = [
             test for test, _ in summary.errors + summary.failures]
-        output.output_tests(failing_tests)
+        output.output_tests(failing_tests, output=stdout)
     return result

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -57,7 +57,7 @@ def run(arguments):
 
 
 def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
-         color=False):
+         color=False, stdout=sys.stdout):
     """Show the last run loaded into a a repository
 
     This function will print the results from the last run in the repository
@@ -75,6 +75,8 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
     :param pretty_out: Use the subunit-trace output filter.
     :param color: Enable colorized output with the subunit-trace output filter.
     :param bool subunit: Show output as a subunit stream.
+    :param file stdout: The output file to write all output to. By default
+         this is sys.stdout
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -84,7 +86,7 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
     latest_run = repo.get_latest_run()
     if subunit_out:
         stream = latest_run.get_subunit_stream()
-        output.output_stream(stream)
+        output.output_stream(stream, output=stdout)
         # Exits 0 if we successfully wrote the stream.
         return 0
     case = latest_run.get_test()
@@ -99,7 +101,7 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
         previous_run = None
     failed = False
     if not pretty_out:
-        output_result = results.CLITestResult(latest_run.get_id, sys.stdout,
+        output_result = results.CLITestResult(latest_run.get_id, stdout,
                                               previous_run)
         summary = output_result.get_summary()
         output_result.startTestRun()
@@ -110,7 +112,7 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
         failed = not summary.wasSuccessful()
     else:
         stream = latest_run.get_subunit_stream()
-        failed = subunit_trace.trace(stream, sys.stdout, post_fails=True,
+        failed = subunit_trace.trace(stream, stdout, post_fails=True,
                                      color=color)
     if failed:
         return 1

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -13,6 +13,7 @@
 """List the tests from a project and show them."""
 
 from io import BytesIO
+import sys
 
 from stestr import config_file
 from stestr import output
@@ -59,7 +60,7 @@ def run(arguments):
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
                  blacklist_file=None, whitelist_file=None, black_regex=None,
-                 filters=None):
+                 filters=None, stdout=sys.stdout):
     """Print a list of test_ids for a project
 
     This function will print the test_ids for tests in a project. You can
@@ -88,6 +89,9 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
     :param list filters: A list of string regex filters to initially apply on
         the test list. Tests that match any of the regexes will be used.
         (assuming any other filtering specified also uses it)
+    :param file stdout: The output file to write all output to. By default
+        this is sys.stdout
+
     """
     ids = None
     conf = config_file.TestrConf(config)
@@ -109,7 +113,7 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         for id in ids:
             stream.write(('%s\n' % id).encode('utf8'))
         stream.seek(0)
-        output.output_stream(stream)
+        output.output_stream(stream, output=stdout)
         return 0
     finally:
         cmd.cleanUp()

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -73,7 +73,8 @@ def run(arguments):
 
 def load(force_init=False, in_streams=None,
          partial=False, subunit_out=False, repo_type='file', repo_url=None,
-         run_id=None, streams=None, pretty_out=False, color=False):
+         run_id=None, streams=None, pretty_out=False, color=False,
+         stdout=sys.stdout):
     """Load subunit streams into a repository
 
     This function will load subunit streams into the repository. It will
@@ -95,6 +96,8 @@ def load(force_init=False, in_streams=None,
     :param bool pretty_out: Use the subunit-trace output filter for the loaded
         stream.
     :param bool color: Enabled colorized subunit-trace output
+    :param file stdout: The output file to write all output to. By default
+        this is sys.stdout
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -140,12 +143,12 @@ def load(force_init=False, in_streams=None,
         output_result, summary_result = output.make_result(inserter.get_id)
     if pretty_out:
         outcomes = testtools.StreamToDict(
-            functools.partial(subunit_trace.show_outcome, sys.stdout,
+            functools.partial(subunit_trace.show_outcome, stdout,
                               enable_color=color))
         summary_result = testtools.StreamSummary()
         output_result = testtools.CopyStreamResult([outcomes, summary_result])
         output_result = testtools.StreamResultRouter(output_result)
-        cat = subunit.test_results.CatFiles(sys.stdout)
+        cat = subunit.test_results.CatFiles(stdout)
         output_result.add_rule(cat, 'test_id', test_id=None)
     else:
         try:
@@ -153,7 +156,7 @@ def load(force_init=False, in_streams=None,
         except KeyError:
             previous_run = None
         output_result = results.CLITestResult(
-            inserter.get_id, sys.stdout, previous_run)
+            inserter.get_id, stdout, previous_run)
         summary_result = output_result.get_summary()
     result = testtools.CopyStreamResult([inserter, output_result])
     start_time = datetime.datetime.utcnow()
@@ -165,8 +168,8 @@ def load(force_init=False, in_streams=None,
     stop_time = datetime.datetime.utcnow()
     elapsed_time = stop_time - start_time
     if pretty_out:
-        subunit_trace.print_fails(sys.stdout)
-        subunit_trace.print_summary(sys.stdout, elapsed_time)
+        subunit_trace.print_fails(stdout)
+        subunit_trace.print_summary(stdout, elapsed_time)
     if not summary_result.wasSuccessful():
         return 1
     else:

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -15,6 +15,7 @@
 from math import ceil
 import os
 import subprocess
+import sys
 
 import six
 import subunit
@@ -127,7 +128,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                 analyze_isolation=False, isolated=False, worker_path=None,
                 blacklist_file=None, whitelist_file=None, black_regex=None,
                 no_discover=False, random=False, combine=False, filters=None,
-                pretty_out=True, color=False):
+                pretty_out=True, color=False, stdout=sys.stdout):
     """Function to execute the run command
 
     This function implements the run command. It will run the tests specified
@@ -181,6 +182,8 @@ def run_command(config='.stestr.conf', repo_type='file',
         (assuming any other filtering specified also uses it)
     :param bool pretty_out: Use the subunit-trace output filter
     :param bool color: Enable colorized output in subunit-trace
+    :param file stdout: The file object to write all output to. By default this
+        is sys.stdout
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -194,7 +197,7 @@ def run_command(config='.stestr.conf', repo_type='file',
             msg = ("No config file found and --test-path not specified. "
                    "Either create or specify a .stestr.conf or use "
                    "--test-path ")
-            print(msg)
+            stdout.write(msg)
             exit(1)
         repo = util.get_repo_initialise(repo_type, repo_url)
     combine_id = None
@@ -217,7 +220,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                              repo_type=repo_type,
                              repo_url=repo_url, run_id=combine_id,
                              pretty_out=pretty_out,
-                             color=color)
+                             color=color, stdout=stdout)
 
         if not until_failure:
             return run_tests()
@@ -291,7 +294,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                                         repo_type=repo_type,
                                         repo_url=repo_url,
                                         pretty_out=pretty_out,
-                                        color=color)
+                                        color=color,
+                                        stdout=stdout)
                 if run_result > result:
                     result = run_result
             return result
@@ -303,7 +307,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                               repo_type=repo_type,
                               repo_url=repo_url,
                               pretty_out=pretty_out,
-                              color=color)
+                              color=color,
+                              stdout=stdout)
     else:
         # Where do we source data about the cause of conflicts.
         # XXX: Should instead capture the run id in with the failing test
@@ -448,7 +453,7 @@ def _prior_tests(self, run, failing_id):
 
 def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
                subunit_out=False, combine_id=None, repo_type='file',
-               repo_url=None, pretty_out=True, color=False):
+               repo_url=None, pretty_out=True, color=False, stdout=sys.stdout):
     """Run the tests cmd was parameterised with."""
     cmd.setUp()
     try:
@@ -460,13 +465,13 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
             if (failing or analyze_isolation or isolated):
                 partial = True
             if not run_procs:
-                print("The specified regex doesn't match with anything.")
+                stdout.write("The specified regex doesn't match with anything")
                 return 0
             return load.load((None, None), in_streams=run_procs,
                              partial=partial, subunit_out=subunit_out,
                              repo_type=repo_type,
                              repo_url=repo_url, run_id=combine_id,
-                             pretty_out=pretty_out, color=color)
+                             pretty_out=pretty_out, color=color, stdout=stdout)
 
         if not until_failure:
             return run_tests()

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -466,7 +466,7 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
                 partial = True
             if not run_procs:
                 stdout.write("The specified regex doesn't match with anything")
-                return 0
+                return 1
             return load.load((None, None), in_streams=run_procs,
                              partial=partial, subunit_out=subunit_out,
                              repo_type=repo_type,

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -14,6 +14,7 @@
 
 import math
 from operator import itemgetter
+import sys
 
 from stestr import output
 from stestr.repository import util
@@ -56,7 +57,8 @@ def run(arguments):
                    show_all=args.all)
 
 
-def slowest(repo_type='file', repo_url=None, show_all=False):
+def slowest(repo_type='file', repo_url=None, show_all=False,
+            stdout=sys.stdout):
     """Print the slowest times from the last run in the repository
 
     This function will print to STDOUT the 10 slowests tests in the last run.
@@ -67,6 +69,8 @@ def slowest(repo_type='file', repo_url=None, show_all=False):
         are 'file' and 'sql'.
     :param str repo_url: The url of the repository to use.
     :param bool show_all: Show timing for all tests.
+    :param file stdout: The output file to write all output to. By default
+        this is sys.stdout
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -89,5 +93,5 @@ def slowest(repo_type='file', repo_url=None, show_all=False):
         known_times = format_times(known_times)
         header = ('Test id', 'Runtime (s)')
         rows = [header] + known_times
-        output.output_table(rows)
+        output.output_table(rows, output=stdout)
     return 0

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -74,7 +74,7 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run passing', 0)
 
     def test_parallel_passing_bad_regex(self):
-        self.assertRunExit('stestr run bad.regex.foobar', 0)
+        self.assertRunExit('stestr run bad.regex.foobar', 1)
 
     def test_parallel_fails(self):
         self.assertRunExit('stestr run', 1)


### PR DESCRIPTION
This commit adds a stdout argument to the command functions. If you're
calling a command function from python there are several use cases where
you don't want the output to unconditionally go to stdout. To enable
such use cases this commit adds a stdout arg to all the functions that
write to stdout. By default sys.stdout will be used as before, but any
file object can be used instead.

A bugfix commit is tacked on to the end here, because I found it during the refactor.