### PR TITLE
Fix coveralls collection

### DIFF
--- a/.travis/coveralls.sh
+++ b/.travis/coveralls.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ "$TOXENV" = "cover" ]; then
-    coverall
+    coveralls
 fi


### PR DESCRIPTION
This commit fixes a small typo in the coveralls run script. We haven't
been aggregating coverage data since late May. It looks like this is
because the script to call coveralls was running the coverall command,
but according to the docs this should be coveralls.