### PR TITLE
Add osx test environment to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       env: TOXENV=docs
     - python: "2.7"
       env: TOXENV=py27
+    - os: osx
+      env: TOXENV=py36
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis/coveralls.sh
+++ b/.travis/coveralls.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+python --version
+
 if [ "$TOXENV" = "cover" ]; then
     coverall
 fi


### PR DESCRIPTION
We already validate that stestr works on windows, but people also use
it from osx. This commit adds the travis config bits necessary to also
run unit tests on an osx environment to verify that we keep things
working there.