### PR TITLE
Use context managers for file open()

### DIFF
--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -41,11 +41,8 @@ class RepositoryFactory(repository.AbstractRepositoryFactory):
         """Create a repository at url/path."""
         base = os.path.join(os.path.expanduser(url), '.stestr')
         os.mkdir(base)
-        stream = open(os.path.join(base, 'format'), 'wt')
-        try:
+        with open(os.path.join(base, 'format'), 'wt') as stream:
             stream.write('1\n')
-        finally:
-            stream.close()
         result = Repository(base)
         result._write_next_stream(0)
         return result
@@ -166,11 +163,8 @@ class Repository(repository.AbstractRepository):
         # term. Likewise we don't fsync - this data isn't valuable enough to
         # force disk IO.
         prefix = self._path('next-stream')
-        stream = open(prefix + '.new', 'wt')
-        try:
+        with open(prefix + '.new', 'wt') as stream:
             stream.write('%d\n' % value)
-        finally:
-            stream.close()
         atomicish_rename(prefix + '.new', prefix)
 
 

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import contextlib
 import re
 
 
@@ -36,21 +37,21 @@ def filter_tests(filters, test_ids):
 
 
 def black_reader(blacklist_file):
-    black_file = open(blacklist_file, 'r')
-    regex_comment_lst = []  # tuple of (regex_compiled, msg, skipped_lst)
-    for line in black_file:
-        raw_line = line.strip()
-        split_line = raw_line.split('#')
-        # Before the # is the regex
-        line_regex = split_line[0].strip()
-        if len(split_line) > 1:
-            # After the # is a comment
-            comment = ''.join(split_line[1:]).strip()
-        else:
-            comment = 'Skipped because of regex %s:' % line_regex
-        if not line_regex:
-            continue
-        regex_comment_lst.append((re.compile(line_regex), comment, []))
+    with contextlib.closing(open(blacklist_file, 'r')) as black_file:
+        regex_comment_lst = []  # tuple of (regex_compiled, msg, skipped_lst)
+        for line in black_file:
+            raw_line = line.strip()
+            split_line = raw_line.split('#')
+            # Before the # is the regex
+            line_regex = split_line[0].strip()
+            if len(split_line) > 1:
+                # After the # is a comment
+                comment = ''.join(split_line[1:]).strip()
+            else:
+                comment = 'Skipped because of regex %s:' % line_regex
+            if not line_regex:
+                continue
+            regex_comment_lst.append((re.compile(line_regex), comment, []))
     return regex_comment_lst
 
 

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -170,9 +170,9 @@ class TestProcessorFixture(fixtures.Fixture):
             else:
                 fd, name = tempfile.mkstemp()
                 stream = os.fdopen(fd, 'wb')
-            self.list_file_name = name
-            testlist.write_list(stream, self.test_ids)
-            stream.close()
+            with stream:
+                self.list_file_name = name
+                testlist.write_list(stream, self.test_ids)
         except Exception:
             if name:
                 os.unlink(name)

--- a/stestr/tests/repository/test_file.py
+++ b/stestr/tests/repository/test_file.py
@@ -63,17 +63,11 @@ class TestFileRepository(base.TestCase):
         base = os.path.join(self.tempdir, '.stestr')
         self.assertTrue(os.path.isdir(base))
         self.assertTrue(os.path.isfile(os.path.join(base, 'format')))
-        stream = open(os.path.join(base, 'format'), 'rt')
-        try:
+        with open(os.path.join(base, 'format'), 'rt') as stream:
             contents = stream.read()
-        finally:
-            stream.close()
         self.assertEqual("1\n", contents)
-        stream = open(os.path.join(base, 'next-stream'), 'rt')
-        try:
+        with open(os.path.join(base, 'next-stream'), 'rt') as stream:
             contents = stream.read()
-        finally:
-            stream.close()
         self.assertEqual("0\n", contents)
 
     # Skip if windows since ~ in a path doesn't work there

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -23,8 +23,6 @@ from six import StringIO
 
 from stestr.tests import base
 
-DEVNULL = open(os.devnull, 'wb')
-
 
 class TestReturnCodes(base.TestCase):
     def setUp(self):

--- a/tools/testr_to_stestr.py
+++ b/tools/testr_to_stestr.py
@@ -21,14 +21,15 @@ if not os.path.isfile('.testr.conf'):
     print("Testr config file not found")
     sys.exit(1)
 
-testr_conf_file = open('.testr.conf', 'r')
-config = six.moves.configparser.ConfigParser()
-config.readfp(testr_conf_file)
+with open('.testr.conf', 'r') as testr_conf_file:
+    config = six.moves.configparser.ConfigParser()
+    config.readfp(testr_conf_file)
 
-test_command = config.get('DEFAULT', 'test_command')
-group_regex = None
-if config.has_option('DEFAULT', 'group_regex'):
-    group_regex = config.get('DEFAULT', 'group_regex')
+    test_command = config.get('DEFAULT', 'test_command')
+    group_regex = None
+    if config.has_option('DEFAULT', 'group_regex'):
+        group_regex = config.get('DEFAULT', 'group_regex')
+
 top_dir = None
 test_dir = None
 for line in test_command.split('\n'):
@@ -44,11 +45,10 @@ for line in test_command.split('\n'):
                 if val == 'discover':
                     test_dir = command_parts[idx + 2]
 
-stestr_conf_file = open('.stestr.conf', 'w')
-stestr_conf_file.write('[DEFAULT]\n')
-stestr_conf_file.write('test_path=%s\n' % test_dir)
-if top_dir:
-    stestr_conf_file.write('top_dir=%s\n' % top_dir)
-if group_regex:
-    stestr_conf_file.write('group_regex=%s\n' % group_regex)
-stestr_conf_file.close()
+with open('.stestr.conf', 'w') as stestr_conf_file:
+    stestr_conf_file.write('[DEFAULT]\n')
+    stestr_conf_file.write('test_path=%s\n' % test_dir)
+    if top_dir:
+        stestr_conf_file.write('top_dir=%s\n' % top_dir)
+    if group_regex:
+        stestr_conf_file.write('group_regex=%s\n' % group_regex)


### PR DESCRIPTION
This commit tries to use context managers for file open(). In the
previous commit, it already has been done as a bug fix. However, these
also can be fixed to close files. In some cases, the original code are
not harmful, but I changed it to keep the code clean.