### PR TITLE
Update the trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,18 +6,19 @@ description-file =
 author = Matthew Treinish
 author-email = mtreinish@kortar.org
 classifier =
-    Environment :: OpenStack
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
+    Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Topic :: Software Development :: Testing
+    Topic :: Software Development :: Quality Assurance
 
 [files]
 packages =


### PR DESCRIPTION
The trove classifiers for stestr are a bit inaccurate, mostly because I
copy and pasted the original setup.cfg from another project. This commit
updates the classifiers in the setup.cfg to better reflect reality.