### PR TITLE
Remove pyc files before running stestr in tox

### DIFF
--- a/tools/find_and_rm.py
+++ b/tools/find_and_rm.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+def find_and_remove(suffix='.pyc'):
+    for root, dirs, files in os.walk('.'):
+        for file in files:
+            target = os.path.join(root, file)
+            if os.path.isfile(target) and target.endswith(suffix):
+                os.remove(target)
+
+
+if __name__ == '__main__':
+    find_and_remove()

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ whitelist_externals = find
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
+    python tools/find_and_rm.py
     stestr run {posargs}
 
 [testenv:pep8]


### PR DESCRIPTION
This commit add a removing *.pyc files command before running stestr in
tox. Sometimes, old *.pyc files are remaining. It is not good,
basically.