### PR TITLE
Add a --abbreviate flag to stestr run and load

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -162,6 +162,9 @@ colorization with subunit-trace output. If you prefer to deal with the raw
 subunit yourself and run your own output rendering or filtering you can use
 the ``--subunit`` flag to output the result stream as raw subunit v2.
 
+There is also an ``--abbreviate`` flag availble, when this is used a single
+character is printed for each test as it is executed. A ``.`` is printed for a
+successful test, a ``F`` for a failed test, and a ``S`` for a skipped test.
 
 
 Combining Test Results

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -49,6 +49,9 @@ def set_cli_opts(parser):
                         help='Enable color output in the subunit-trace output,'
                              ' if subunit-trace output is enabled. If '
                              'subunit-trace is disable this does nothing.')
+    parser.add_argument('--abbreviate', action='store_true',
+                        dest='abbreviate',
+                        help='Print one character status for each test')
 
 
 def get_cli_help():
@@ -68,13 +71,14 @@ def run(arguments):
     load(repo_type=args.repo_type, repo_url=args.repo_url,
          partial=args.partial, subunit_out=args.subunit,
          force_init=args.force_init, streams=arguments[1],
-         pretty_out=args.subunit_trace, color=args.color)
+         pretty_out=args.subunit_trace, color=args.color,
+         abbreviate=args.abbreviate)
 
 
 def load(force_init=False, in_streams=None,
          partial=False, subunit_out=False, repo_type='file', repo_url=None,
          run_id=None, streams=None, pretty_out=False, color=False,
-         stdout=sys.stdout):
+         stdout=sys.stdout, abbreviate=False):
     """Load subunit streams into a repository
 
     This function will load subunit streams into the repository. It will
@@ -98,6 +102,7 @@ def load(force_init=False, in_streams=None,
     :param bool color: Enabled colorized subunit-trace output
     :param file stdout: The output file to write all output to. By default
         this is sys.stdout
+    :param bool abbreviate: Use abbreviated output if set true
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -144,7 +149,7 @@ def load(force_init=False, in_streams=None,
     if pretty_out:
         outcomes = testtools.StreamToDict(
             functools.partial(subunit_trace.show_outcome, stdout,
-                              enable_color=color))
+                              enable_color=color, abbreviate=abbreviate))
         summary_result = testtools.StreamSummary()
         output_result = testtools.CopyStreamResult([outcomes, summary_result])
         output_result = testtools.StreamResultRouter(output_result)

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -96,6 +96,9 @@ def set_cli_opts(parser):
                              ' if subunit-trace output is enabled. (this is '
                              'the default). If subunit-trace is disable this '
                              ' does nothing.')
+    parser.add_argument('--abbreviate', action='store_true',
+                        dest='abbreviate',
+                        help='Print one character status for each test')
 
 
 def get_cli_help():
@@ -128,7 +131,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                 analyze_isolation=False, isolated=False, worker_path=None,
                 blacklist_file=None, whitelist_file=None, black_regex=None,
                 no_discover=False, random=False, combine=False, filters=None,
-                pretty_out=True, color=False, stdout=sys.stdout):
+                pretty_out=True, color=False, stdout=sys.stdout,
+                abbreviate=False):
     """Function to execute the run command
 
     This function implements the run command. It will run the tests specified
@@ -184,6 +188,7 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param bool color: Enable colorized output in subunit-trace
     :param file stdout: The file object to write all output to. By default this
         is sys.stdout
+    :param bool abbreviate: Use abbreviated output if set true
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -220,7 +225,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                              repo_type=repo_type,
                              repo_url=repo_url, run_id=combine_id,
                              pretty_out=pretty_out,
-                             color=color, stdout=stdout)
+                             color=color, stdout=stdout, abbreviate=abbreviate)
 
         if not until_failure:
             return run_tests()
@@ -296,6 +301,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                                         repo_url=repo_url,
                                         pretty_out=pretty_out,
                                         color=color,
+                                        abbreviate=abbreviate,
                                         stdout=stdout)
                 if run_result > result:
                     result = run_result
@@ -309,7 +315,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                               repo_url=repo_url,
                               pretty_out=pretty_out,
                               color=color,
-                              stdout=stdout)
+                              stdout=stdout,
+                              abbreviate=abbreviate)
     else:
         # Where do we source data about the cause of conflicts.
         # XXX: Should instead capture the run id in with the failing test
@@ -455,7 +462,8 @@ def _prior_tests(self, run, failing_id):
 
 def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
                subunit_out=False, combine_id=None, repo_type='file',
-               repo_url=None, pretty_out=True, color=False, stdout=sys.stdout):
+               repo_url=None, pretty_out=True, color=False, stdout=sys.stdout,
+               abbreviate=False):
     """Run the tests cmd was parameterised with."""
     cmd.setUp()
     try:
@@ -473,7 +481,8 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
                              partial=partial, subunit_out=subunit_out,
                              repo_type=repo_type,
                              repo_url=repo_url, run_id=combine_id,
-                             pretty_out=pretty_out, color=color, stdout=stdout)
+                             pretty_out=pretty_out, color=color, stdout=stdout,
+                             abbreviate=abbreviate)
 
         if not until_failure:
             return run_tests()
@@ -517,4 +526,5 @@ def run(arguments):
         worker_path=args.worker_path, blacklist_file=args.blacklist_file,
         whitelist_file=args.whitelist_file, black_regex=args.black_regex,
         no_discover=args.no_discover, random=args.random, combine=args.combine,
-        filters=filters, pretty_out=pretty_out, color=args.color)
+        filters=filters, pretty_out=pretty_out, color=args.color,
+        abbreviate=args.abbreviate)


### PR DESCRIPTION
This commit adds a new flag to the stestr run and load comands for
printing abbreviated output. By default the full subunit-trace output is
used, but in some cases this is overly verbose. To enable a tradeoff
between the full verbosity and the blank output during execution this
flag will print a single character as each test executes.