### PR TITLE
Use cliff for CLI layer

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -25,34 +25,31 @@ These modules are used for the operation of all the various subcommands in
 stestr. As of the 1.0.0 release each of these commands should be considered
 a stable interface that can be relied on externally.
 
-Each command module conforms to a basic format that is used by ``stestr.cli``
-to load each command. The basic structure for these modules is the following
-three functions::
+Each command module conforms to a basic format that is based on the
+`cliff`_ framework. The basic structure for these modules is the
+following three functions in each class::
 
-  def get_cli_help():
+  def get_description():
       """This function returns a string that is used for the subcommand help"""
       help_str = "A descriptive help string about the command"
       return help_str
 
-  def get_cli_opts(parser):
+  def get_parser(prog_name):
       """This function takes a parser and any subcommand arguments are defined
          here"""
       parser.add_argument(...)
 
-  def run(arguments):
-      """This function actually runs the command. It takes in a tuple arguments
-         which the first element is the argparse Namespace object with the
-         arguments from the parser. The second element is a list of unknown
-         arguments from the CLI. The expectation of the run method is that it
-         will process the arguments and call another function that does the
-         real work. The return value is expected to be an int and is used for
-         the exit code (assuming the function doesn't call sys.exit() on it's
-         own)"""
-      args = arguments[0]
-      unknown_args = arguments[1]
-      return call_foo()
+  def take_action(parsed_args):
+      """This is where the real work for the command is performed. This is the function
+         that is called when the command is executed. This function is called being
+         wrapped by sys.exit() so an integer return is expected that will be used
+         for the command's return code. The arguments input parsed_args is the
+         argparse.Namespace object from the parsed CLI options."""
+      return call_foo(...)
 
-The command module will not work if all 3 of these function are not defined.
+.. _cliff: https://docs.openstack.org/cliff/latest/reference/index.html
+
+The command class will not work if all 3 of these function are not defined.
 However, to make the commands externally consumable each module also contains
 another public function which performs the real work for the command. Each one
 of these functions has a defined stable Python API signature with args and

--- a/doc/source/internal_arch.rst
+++ b/doc/source/internal_arch.rst
@@ -27,17 +27,22 @@ the command line interface for performing the different stestr operations.
 
 CLI Layer
 ---------
-The CLI layer is built using modular subcommands in argparse. The stestr.cli
-module defines a basic interface using argparse and then loops over a list of
-command modules in stestr.commands. Each subcommand has its own module in
-stestr.commands and has 3 required functions to work properly:
+The CLI layer is built using the `cliff.command`_ module. The
+stestr.cli module defines a basic interface using cliff. Each
+subcommand has its own module in stestr.commands and has 3 required
+functions to work properly:
 
- #. set_cli_opts(parser)
- #. get_cli_help()
- #. run(arguments)
+ #. get_parser(prog_name)
+ #. get_description()
+ #. take_action(parsed_args)
 
-set_cli_opts(parser)
-''''''''''''''''''''
+NOTE: To keep the api compatibility in stestr.commands, we still have
+each subcommands there.
+
+.. _cliff.command: https://docs.openstack.org/cliff/latest/reference/index.html
+
+get_parser(prog_name)
+'''''''''''''''''''''
 
 This function is used to define subcommand arguments. It has a single argparse
 parser object passed into it. The intent of this function is to have any command
@@ -46,24 +51,20 @@ specific arguments defined on the provided parser object by calling
 
 .. _parser.add_argument(): https://docs.python.org/2/library/argparse.html#the-add-argument-method
 
-get_cli_help()
-''''''''''''''
+get_description()
+'''''''''''''''''
 The intent of this function is to return an command specific help information.
 It is expected to return a string that will be used when the subcommand is
 defined in argparse and will be displayed before the arguments when --help is
 used on the subcommand.
 
-run(arguments)
-''''''''''''''
+take_action(parsed_args)
+''''''''''''''''''''''''
 This is where the real work for the command is performed. This is the function
 that is called when the command is executed. This function is called being
 wrapped by sys.exit() so an integer return is expected that will be used
-for the command's return code. The arguments input arg is a tuple, the first
-element is the argparse.Namespace object from the parsed CLI options and the
-second element is a list of unknown arguments from the CLI. The expectation
-is that this function will call a separate function with a real python API
-that does all the real work. (which is the public python interface for the
-command)
+for the command's return code. The arguments input parsed_args is the
+argparse.Namespace object from the parsed CLI options.
 
 
 Operations for Running Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 future
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
+cliff>=2.8.0 # Apache-2.0
 python-subunit>=0.18.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD
 six>=1.10.0 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,15 @@ packages =
 console_scripts =
     stestr = stestr.cli:main
 
+stestr.cm =
+    run = stestr.commands.run:Run
+    failing = stestr.commands.failing:Failing
+    init = stestr.commands.init:Init
+    last = stestr.commands.last:Last
+    list = stestr.commands.list:List
+    load = stestr.commands.load:Load
+    slowest = stestr.commands.slowest:Slowest
+
 [extras]
 sql =
     subunit2sql>=1.8.0

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -14,6 +14,7 @@
 
 import sys
 
+from cliff import command
 import testtools
 
 from stestr import output
@@ -21,17 +22,25 @@ from stestr.repository import util
 from stestr import results
 
 
-def get_cli_help():
-    return "Show the current failures known by the repository"
+class Failing(command.Command):
+    def get_description(self):
+        return "Show the current failures known by the repository"
 
+    def get_parser(self, prog_name):
+        parser = super(Failing, self).get_parser(prog_name)
+        parser.add_argument(
+            "--subunit", action="store_true",
+            default=False, help="Show output as a subunit stream.")
+        parser.add_argument(
+            "--list", action="store_true",
+            default=False, help="Show only a list of failing tests.")
+        return parser
 
-def set_cli_opts(parser):
-    parser.add_argument(
-        "--subunit", action="store_true",
-        default=False, help="Show output as a subunit stream."),
-    parser.add_argument(
-        "--list", action="store_true",
-        default=False, help="Show only a list of failing tests."),
+    def take_action(self, parsed_args):
+        args = parsed_args
+        return failing(repo_type=self.app_args.repo_type,
+                       repo_url=self.app_args.repo_url,
+                       list_tests=args.list, subunit=args.subunit)
 
 
 def _show_subunit(run):
@@ -55,12 +64,6 @@ def _make_result(repo, list_tests=False, stdout=sys.stdout):
                                               stdout, None)
         summary_result = output_result.get_summary()
         return output_result, summary_result
-
-
-def run(arguments):
-    args = arguments[0]
-    return failing(repo_type=args.repo_type, repo_url=args.repo_url,
-                   list_tests=args.list, subunit=args.subunit)
 
 
 def failing(repo_type='file', repo_url=None, list_tests=False, subunit=False,

--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -14,12 +14,18 @@
 
 import sys
 
+from cliff import command
+
 from stestr.repository import util
 
 
-def run(arguments):
-    args = arguments[0]
-    init(args.repo_type, args.repo_url)
+class Init(command.Command):
+    def take_action(self, parsed_args):
+        init(self.app_args.repo_type, self.app_args.repo_url)
+
+    def get_description(self):
+        help_str = "Create a new repository."
+        return help_str
 
 
 def init(repo_type='file', repo_url=None, stdout=sys.stdout):
@@ -50,12 +56,3 @@ def init(repo_type='file', repo_url=None, stdout=sys.stdout):
                      'Please check if the repository already exists or '
                      'select a different path\n' % repo_path)
         return 1
-
-
-def set_cli_opts(parser):
-    pass
-
-
-def get_cli_help():
-    help_str = "Create a new repository."
-    return help_str

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -14,6 +14,8 @@
 
 import sys
 
+from cliff import command
+
 from stestr import output
 from stestr.repository import abstract
 from stestr.repository import util
@@ -21,40 +23,42 @@ from stestr import results
 from stestr import subunit_trace
 
 
-def get_cli_help():
-    help_str = """Show the last run loaded into a repository.
+class Last(command.Command):
+    def get_description(self):
+        help_str = """Show the last run loaded into a repository.
 
-    Failing tests are shown on the console and a summary of the run is printed
-    at the end.
+        Failing tests are shown on the console and a summary of the run is
+        printed at the end.
 
-    Without --subunit, the process exit code will be non-zero if the test run
-    was not successful. With --subunit, the process exit code is non-zero if
-    the subunit stream could not be generated successfully.
-    """
-    return help_str
+        Without --subunit, the process exit code will be non-zero if the test
+        run was not successful. With --subunit, the process exit code is
+        non-zero if the subunit stream could not be generated successfully.
+        """
+        return help_str
 
+    def get_parser(self, prog_name):
+        parser = super(Last, self).get_parser(prog_name)
+        parser.add_argument(
+            "--subunit", action="store_true",
+            default=False, help="Show output as a subunit stream.")
+        parser.add_argument("--no-subunit-trace", action='store_true',
+                            default=False,
+                            help="Disable output with the subunit-trace "
+                            "output filter")
+        parser.add_argument('--color', action='store_true', default=False,
+                            help='Enable color output in the subunit-trace '
+                            'output, if subunit-trace output is enabled. '
+                            '(this is the default). If subunit-trace is '
+                            'disable this does nothing.')
+        return parser
 
-def set_cli_opts(parser):
-    parser.add_argument(
-        "--subunit", action="store_true",
-        default=False, help="Show output as a subunit stream.")
-    parser.add_argument("--no-subunit-trace", action='store_true',
-                        default=False,
-                        help="Disable output with the subunit-trace output "
-                             "filter")
-    parser.add_argument('--color', action='store_true', default=False,
-                        help='Enable color output in the subunit-trace output,'
-                             ' if subunit-trace output is enabled. (this is '
-                             'the default). If subunit-trace is disable this '
-                             ' does nothing.')
-
-
-def run(arguments):
-    args = arguments[0]
-    pretty_out = not args.no_subunit_trace
-    return last(repo_type=args.repo_type, repo_url=args.repo_url,
-                subunit_out=args.subunit, pretty_out=pretty_out,
-                color=args.color)
+    def take_action(self, parsed_args):
+        args = parsed_args
+        pretty_out = not args.no_subunit_trace
+        return last(repo_type=self.app_args.repo_type,
+                    repo_url=self.app_args.repo_url,
+                    subunit_out=args.subunit, pretty_out=pretty_out,
+                    color=args.color)
 
 
 def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -15,47 +15,61 @@
 from io import BytesIO
 import sys
 
+from cliff import command
+
 from stestr import config_file
 from stestr import output
 
 
-def get_cli_help():
-    help_str = ("List the tests for a project. You can use a filter just like"
-                "with the run command to see exactly what tests match")
-    return help_str
+class List(command.Command):
 
+    def get_description(self):
+        help_str = ("List the tests for a project. You can use a filter just "
+                    "like with the run command to see exactly what tests "
+                    "match")
+        return help_str
 
-def set_cli_opts(parser):
-    parser.add_argument('--blacklist-file', '-b',
-                        default=None, dest='blacklist_file',
-                        help='Path to a blacklist file, this file '
-                             'contains a separate regex exclude on each '
-                             'newline')
-    parser.add_argument('--whitelist-file', '-w',
-                        default=None, dest='whitelist_file',
-                        help='Path to a whitelist file, this file '
-                             'contains a separate regex on each newline.')
-    parser.add_argument('--black-regex', '-B',
-                        default=None, dest='black_regex',
-                        help='Test rejection regex. If a test cases name '
-                        'matches on re.search() operation , '
-                        'it will be removed from the final test list. '
-                        'Effectively the black-regexp is added to '
-                        ' black regexp list, but you do need to edit a file. '
-                        'The black filtering happens after the initial '
-                        ' white selection, which by default is everything.')
+    def get_parser(self, prog_name):
+        parser = super(List, self).get_parser(prog_name)
+        parser.add_argument("filters", nargs="*", default=None,
+                            help="A list of string regex filters to initially "
+                            "apply on the test list. Tests that match any of "
+                            "the regexes will be used. (assuming any other "
+                            "filtering specified also uses it)")
+        parser.add_argument('--blacklist-file', '-b',
+                            default=None, dest='blacklist_file',
+                            help='Path to a blacklist file, this file '
+                                 'contains a separate regex exclude on each '
+                                 'newline')
+        parser.add_argument('--whitelist-file', '-w',
+                            default=None, dest='whitelist_file',
+                            help='Path to a whitelist file, this file '
+                                 'contains a separate regex on each newline.')
+        parser.add_argument('--black-regex', '-B',
+                            default=None, dest='black_regex',
+                            help='Test rejection regex. If a test cases name '
+                            'matches on re.search() operation , '
+                            'it will be removed from the final test list. '
+                            'Effectively the black-regexp is added to '
+                            ' black regexp list, but you do need to edit a '
+                            'file. The black filtering happens after the '
+                            'initial white selection, which by default is '
+                            'everything.')
+        return parser
 
-
-def run(arguments):
-    args = arguments[0]
-    filters = arguments[1]
-    return list_command(config=args.config, repo_type=args.repo_type,
-                        repo_url=args.repo_url, group_regex=args.group_regex,
-                        test_path=args.test_path, top_dir=args.top_dir,
-                        blacklist_file=args.blacklist_file,
-                        whitelist_file=args.whitelist_file,
-                        black_regex=args.black_regex,
-                        filters=filters)
+    def take_action(self, parsed_args):
+        args = parsed_args
+        filters = parsed_args.filters
+        return list_command(config=self.app_args.config,
+                            repo_type=self.app_args.repo_type,
+                            repo_url=self.app_args.repo_url,
+                            group_regex=self.app_args.group_regex,
+                            test_path=self.app_args.test_path,
+                            top_dir=self.app_args.top_dir,
+                            blacklist_file=args.blacklist_file,
+                            whitelist_file=args.whitelist_file,
+                            black_regex=args.black_regex,
+                            filters=filters)
 
 
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -114,7 +114,8 @@ class Run(command.Command):
                             '(this is the default). If subunit-trace is '
                             'disable this does nothing.')
         parser.add_argument('--slowest', action='store_true', default=False,
-                            help='After the test run, print the slowest tests.')
+                            help='After the test run, print the slowest '
+                            'tests.')
         parser.add_argument('--abbreviate', action='store_true',
                             dest='abbreviate',
                             help='Print one character status for each test')
@@ -147,8 +148,8 @@ class Run(command.Command):
             filters=filters, pretty_out=pretty_out, color=args.color,
             stdout=stdout, abbreviate=args.abbreviate)
 
-        # Always output slowest test info if requested, regardless of other test
-        # run options
+        # Always output slowest test info if requested, regardless of other
+        # test run options
         if args.slowest:
             slowest.slowest(repo_type=args.repo_type, repo_url=args.repo_url)
 
@@ -457,4 +458,3 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
                     return result
     finally:
         cmd.cleanUp()
-        

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -16,23 +16,33 @@ import math
 from operator import itemgetter
 import sys
 
+from cliff import command
+
 from stestr import output
 from stestr.repository import util
 
 
-def get_cli_help():
-    help_str = """Show the slowest tests from the last test run.
+class Slowest(command.Command):
+    def get_description(self):
+        help_str = """Show the slowest tests from the last test run.
 
-    This command shows a table, with the longest running
-    tests at the top.
-    """
-    return help_str
+        This command shows a table, with the longest running
+        tests at the top.
+        """
+        return help_str
 
+    def get_parser(self, prog_name):
+        parser = super(Slowest, self).get_parser(prog_name)
+        parser.add_argument(
+            "--all", action="store_true",
+            default=False, help="Show timing for all tests.")
+        return parser
 
-def set_cli_opts(parser):
-    parser.add_argument(
-        "--all", action="store_true",
-        default=False, help="Show timing for all tests."),
+    def take_action(self, parsed_args):
+        args = parsed_args
+        return slowest(repo_type=self.app_args.repo_type,
+                       repo_url=self.app_args.repo_url,
+                       show_all=args.all)
 
 
 def format_times(times):
@@ -49,12 +59,6 @@ def format_times(times):
         return "%*.*f" % (min_length, precision, time)
     times = [(name, format_time(time)) for name, time in times]
     return times
-
-
-def run(arguments):
-    args = arguments[0]
-    return slowest(repo_type=args.repo_type, repo_url=args.repo_url,
-                   show_all=args.all)
 
 
 def slowest(repo_type='file', repo_url=None, show_all=False,

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -162,9 +162,6 @@ class TestReturnCodes(base.TestCase):
     def test_list(self):
         self.assertRunExit('stestr list', 0)
 
-    def test_no_command(self):
-        self.assertRunExit('stestr', 2)
-
     def _get_cmd_stdout(self, cmd):
         p = subprocess.Popen(cmd, shell=True,
                              stdout=subprocess.PIPE)


### PR DESCRIPTION
This commit makes stestr use cliff[1] for CLI layer. The cliff project
provides a lot of advantages for stestr cli which has subcommands.
Instead of just using argparse, we should leverage cliff to provide a
more plished CLI experience.

[1] https://pypi.python.org/pypi/cliff

Closes Issue #62