### PR TITLE
Fix if logic on output types in stestr load

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -146,7 +146,7 @@ def load(force_init=False, in_streams=None,
         inserter = repo.get_inserter(partial=partial, run_id=run_id)
     if subunit_out:
         output_result, summary_result = output.make_result(inserter.get_id)
-    if pretty_out:
+    elif pretty_out:
         outcomes = testtools.StreamToDict(
             functools.partial(subunit_trace.show_outcome, stdout,
                               enable_color=color, abbreviate=abbreviate))
@@ -172,7 +172,7 @@ def load(force_init=False, in_streams=None,
         result.stopTestRun()
     stop_time = datetime.datetime.utcnow()
     elapsed_time = stop_time - start_time
-    if pretty_out:
+    if pretty_out and not subunit_out:
         subunit_trace.print_fails(stdout)
         subunit_trace.print_summary(stdout, elapsed_time)
     if not summary_result.wasSuccessful():


### PR DESCRIPTION
The if logic in stestr load was incorrect and when subunit_out was
specified it would set the right variables, but then override them later
in the code path. This commit fixes it so that when subunit_out is used
those settings hold true until the actual stream is run. In the process
another bug was fixed when subunit_out and pretty_out were both set the
subunit_trace summary was still printed because of a similar if logic
issue.

Closes Issue #101