### PR TITLE
Fix .testr.conf parsing: test path follows discover

### DIFF
--- a/tools/testr_to_stestr.py
+++ b/tools/testr_to_stestr.py
@@ -43,7 +43,7 @@ for line in test_command.split('\n'):
                     test_dir = command_parts[idx + 2]
             else:
                 if val == 'discover':
-                    test_dir = command_parts[idx + 2]
+                    test_dir = command_parts[idx + 1]
 
 with open('.stestr.conf', 'w') as stestr_conf_file:
     stestr_conf_file.write('[DEFAULT]\n')


### PR DESCRIPTION
Apparently if -t is not specified, the path to the unit test directory
follows immediately the "discover" keyword.

This change was applied to and tested against the similar code inside
ostestr which parses and coverts .testr.conf on the fly:
https://review.openstack.org/503877/