### PR TITLE
Respect all selection mechanisms for discovery check

### DIFF
--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -115,6 +115,8 @@ class TestProcessorFixture(fixtures.Fixture):
 
         self.list_cmd = re.sub(variable_regex, list_subst, cmd)
         nonparallel = not self.parallel
+        selection_logic = (self.test_filters or self.blacklist_file or
+                           self.whitelist_file or self.black_regex)
         if nonparallel:
             self.concurrency = 1
         else:
@@ -129,8 +131,7 @@ class TestProcessorFixture(fixtures.Fixture):
             if self.concurrency == 1:
                 if default_idstr:
                     self.test_ids = default_idstr.split()
-            if self.concurrency != 1 or self.test_filters is not None \
-                    or self.worker_path:
+            if self.concurrency != 1 or selection_logic or self.worker_path:
                 # Have to be able to tell each worker what to run / filter
                 # tests.
                 self.test_ids = self.list_tests()

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -77,11 +77,43 @@ class TestReturnCodes(base.TestCase):
     def test_parallel_fails(self):
         self.assertRunExit('stestr run', 1)
 
+    def test_parallel_blacklist(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as blacklist:
+            blacklist.write('fail')
+        cmd = 'stestr run --blacklist-file %s' % path
+        self.assertRunExit(cmd, 0)
+
+    def test_parallel_whitelist(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as whitelist:
+            whitelist.write('passing')
+        cmd = 'stestr run --whitelist-file %s' % path
+        self.assertRunExit(cmd, 0)
+
     def test_serial_passing(self):
         self.assertRunExit('stestr run --serial passing', 0)
 
     def test_serial_fails(self):
         self.assertRunExit('stestr run --serial', 1)
+
+    def test_serial_blacklist(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as blacklist:
+            blacklist.write('fail')
+        cmd = 'stestr run --serial --blacklist-file %s' % path
+        self.assertRunExit(cmd, 0)
+
+    def test_serial_whitelist(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as whitelist:
+            whitelist.write('passing')
+        cmd = 'stestr run --serial --whitelist-file %s' % path
+        self.assertRunExit(cmd, 0)
 
     def test_serial_subunit_passing(self):
         self.assertRunExit('stestr run --subunit passing', 0,


### PR DESCRIPTION
When test_processor is doing it's initial test_id list generation it has
to determine whether or not discovery is necessary. Whenever a dynamic
test selection mechanism (regex, black regex, whitelist, or blacklist)
is used running discovery is necessary if test_ids aren't supplied.
However, the check for this only understood the normal regex and wasn't
checking if any of the other selection mechanisms were in use. This
commit fixes this issue by checking if any of the selection mechanisms
are in use instead of just a regex.

Fixes issue #103