### PR TITLE
Fix stestr load from stdin

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -125,7 +125,7 @@ def load(force_init=False, in_streams=None,
         opener = functools.partial(open, mode='rb')
         streams = map(opener, streams)
     else:
-        streams = [sys.stdin.buffer]
+        streams = [sys.stdin]
 
     def mktagger(pos, result):
         return testtools.StreamTagger([result], add=['worker-%d' % pos])

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -57,11 +57,17 @@ class TestReturnCodes(base.TestCase):
         os.chdir(self.directory)
         subprocess.call('stestr init', shell=True)
 
-    def assertRunExit(self, cmd, expected, subunit=False):
-        p = subprocess.Popen(
-            "%s" % cmd, shell=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
+    def assertRunExit(self, cmd, expected, subunit=False, stdin=None):
+        if stdin:
+            p = subprocess.Popen(
+                "%s" % cmd, shell=True, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate(stdin)
+        else:
+            p = subprocess.Popen(
+                "%s" % cmd, shell=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
 
         if not subunit:
             self.assertEqual(
@@ -187,3 +193,9 @@ class TestReturnCodes(base.TestCase):
         # The test results from running the same tests twice with combine
         # should return a test count 2x as big at the end of the run
         self.assertEqual(test_count * 2, combine_test_count)
+
+    def test_load_from_stdin(self):
+        self.assertRunExit('stestr run passing', 0)
+        stream = self._get_cmd_stdout(
+            'stestr last --subunit')[0]
+        self.assertRunExit('stestr load', 0, stdin=stream)


### PR DESCRIPTION
This commit fixes a bug in stestr load when passing in a subunit stream
from stdin. It was previously trying to read the stream form the stdin
buffer, but that doesn't always (and in most cases) exist. It turns out
there was no need to do this, so this commit just fixes that by using
the stdin object itself.

Fixes #109