### PR TITLE
Fix the stestr run --analyze-isolation flag

### DIFF
--- a/stestr/bisect_tests.py
+++ b/stestr/bisect_tests.py
@@ -31,7 +31,7 @@ class IsolationAnalyzer(object):
         self.repo_type = repo_type
         self.repo_url = repo_url
         self.serial = serial
-        self.concurrency = concurrency,
+        self.concurrency = concurrency
         self.test_path = test_path
         self.top_dir = top_dir
         self.run_func = run_func
@@ -57,7 +57,7 @@ class IsolationAnalyzer(object):
                     repo_type=self.repo_type, repo_url=self.repo_url,
                     serial=self.serial, concurrency=self.concurrency,
                     test_path=self.test_path, top_dir=self.top_dir)
-                self.run_func(cmd, True, True, False, False,
+                self.run_func(cmd, False, True, False, False,
                               pretty_out=False,
                               repo_type=self.repo_type,
                               repo_url=self.repo_url)

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -318,6 +318,11 @@ def run_command(config='.stestr.conf', repo_type='file',
                               stdout=stdout,
                               abbreviate=abbreviate)
     else:
+        # Where do we source data about the cause of conflicts.
+        # XXX: Should instead capture the run id in with the failing test
+        # data so that we can deal with failures split across many partial
+        # runs.
+        latest_run = repo.get_latest_run()
         # Stage one: reduce the list of failing tests (possibly further
         # reduced by testfilters) to eliminate fails-on-own tests.
         spurious_failures = set()
@@ -348,11 +353,6 @@ def run_command(config='.stestr.conf', repo_type='file',
         if not spurious_failures:
             # All done.
             return 0
-        # Where do we source data about the cause of conflicts.
-        # XXX: Should instead capture the run id in with the failing test
-        # data so that we can deal with failures split across many partial
-        # runs.
-        latest_run = repo.get_latest_run()
         bisect_runner = bisect_tests.IsolationAnalyzer(
             latest_run, conf, _run_tests, repo, test_path=test_path,
             top_dir=top_dir, group_regex=group_regex, repo_type=repo_type,


### PR DESCRIPTION
The analyze-isolation command was never update after the stestr repo was
forked from testrepository. This code path was still making a bunch of
calls assuming the repo was still laid out like testrepository. This
commit fixes all of these and refactors the test biscet code to live in
it's own class. This also adds tests for this logic to ensure it works.

As it is now this feature will only discover conflicts between tests in
the same process, since it relies in the order of execution on a specific
worker.

More unit tests are needed to fully cover this feature.