### PR TITLE
Remove contributor docs for using reno

### DIFF
--- a/doc/source/developer_guidelines.rst
+++ b/doc/source/developer_guidelines.rst
@@ -23,20 +23,3 @@ Running the tests
 Generally just ``tox`` is all that is needed to run all the tests. However
 if dropping into pdb, it is currently more convenient to use
 ``python -m testtools.run testrepository.tests.test_suite``.
-
-
-Releasing
----------
-
-Add release notes using `reno`_ prior to pushing the release to pypi. Versioning
-is handled automatically by pbr, just make sure the tag is a valid version
-number. The repo uses semver to dictate version number increments.
-
-.. _reno: http://docs.openstack.org/developer/reno/
-
-Release Notes
-'''''''''''''
-When making changes to any user facing interface we need to be sure to add a
-release note documenting the change for the next release. This includes any
-changes to a stable python interfaces that we support externally (including
-adding an API), the CLI, deprecation of a feature, etc.


### PR DESCRIPTION
We haven't really ever used reno for handling release notes, and we
recently removed the releasenotes section from the tree. This commit
just cleans up a stray doc that was telling people to use reno.