### PR TITLE
Fix error handling for unknown arguments

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -48,8 +48,7 @@ three functions::
          real work. The return value is expected to be an int and is used for
          the exit code (assuming the function doesn't call sys.exit() on it's
          own)"""
-      args = arguments[0]
-      unknown_args = arguments[1]
+      args = arguments
       return call_foo()
 
 The command module will not work if all 3 of these function are not defined.

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -91,15 +91,15 @@ class StestrCLI(object):
 
 def main():
     cli = StestrCLI()
-    args = cli.parser.parse_known_args()
-    if args[0].here:
-        os.chdir(args[0].here)
+    args = cli.parser.parse_args()
+    if args.here:
+        os.chdir(args.here)
     # NOTE(mtreinish): Make sure any subprocesses launch the same version of
     # python being run here
     if 'PYTHON' not in os.environ:
         os.environ['PYTHON'] = sys.executable
-    if hasattr(args[0], 'func'):
-        sys.exit(args[0].func(args))
+    if hasattr(args, 'func'):
+        sys.exit(args.func(args))
     else:
         cli.parser.print_help()
         # NOTE(andreaf) This point is reached only when using Python 3.x.

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -58,7 +58,7 @@ def _make_result(repo, list_tests=False, stdout=sys.stdout):
 
 
 def run(arguments):
-    args = arguments[0]
+    args = arguments
     return failing(repo_type=args.repo_type, repo_url=args.repo_url,
                    list_tests=args.list, subunit=args.subunit)
 

--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -18,7 +18,7 @@ from stestr.repository import util
 
 
 def run(arguments):
-    args = arguments[0]
+    args = arguments
     init(args.repo_type, args.repo_url)
 
 

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -50,7 +50,7 @@ def set_cli_opts(parser):
 
 
 def run(arguments):
-    args = arguments[0]
+    args = arguments
     pretty_out = not args.no_subunit_trace
     return last(repo_type=args.repo_type, repo_url=args.repo_url,
                 subunit_out=args.subunit, pretty_out=pretty_out,

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -26,6 +26,11 @@ def get_cli_help():
 
 
 def set_cli_opts(parser):
+    parser.add_argument("filters", nargs="*", default=None,
+                        help="A list of string regex filters to initially "
+                        "apply on the test list. Tests that match any of "
+                        "the regexes will be used. (assuming any other "
+                        "filtering specified also uses it)")
     parser.add_argument('--blacklist-file', '-b',
                         default=None, dest='blacklist_file',
                         help='Path to a blacklist file, this file '
@@ -47,8 +52,8 @@ def set_cli_opts(parser):
 
 
 def run(arguments):
-    args = arguments[0]
-    filters = arguments[1]
+    args = arguments
+    filters = args.filters
     return list_command(config=args.config, repo_type=args.repo_type,
                         repo_url=args.repo_url, group_regex=args.group_regex,
                         test_path=args.test_path, top_dir=args.top_dir,

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -29,6 +29,9 @@ from stestr import utils
 
 
 def set_cli_opts(parser):
+    parser.add_argument("files", nargs="*", default=False,
+                        help="A list of file paths to read for the input "
+                        "streams.")
     parser.add_argument("--partial", action="store_true",
                         default=False,
                         help="The stream being loaded was a partial run.")
@@ -67,10 +70,10 @@ def get_cli_help():
 
 
 def run(arguments):
-    args = arguments[0]
+    args = arguments
     load(repo_type=args.repo_type, repo_url=args.repo_url,
          partial=args.partial, subunit_out=args.subunit,
-         force_init=args.force_init, streams=arguments[1],
+         force_init=args.force_init, streams=args.files,
          pretty_out=args.subunit_trace, color=args.color,
          abbreviate=args.abbreviate)
 

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -30,6 +30,11 @@ from stestr.testlist import parse_list
 
 
 def set_cli_opts(parser):
+    parser.add_argument("filters", nargs="*", default=None,
+                        help="A list of string regex filters to initially "
+                        "apply on the test list. Tests that match any of "
+                        "the regexes will be used. (assuming any other "
+                        "filtering specified also uses it)")
     parser.add_argument("--failing", action="store_true",
                         default=False,
                         help="Run only tests known to be failing.")
@@ -511,8 +516,8 @@ def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
 
 
 def run(arguments):
-    filters = arguments[1] or None
-    args = arguments[0]
+    filters = arguments.filters or None
+    args = arguments
     pretty_out = not args.no_subunit_trace
 
     return run_command(

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -52,7 +52,7 @@ def format_times(times):
 
 
 def run(arguments):
-    args = arguments[0]
+    args = arguments
     return slowest(repo_type=args.repo_type, repo_url=args.repo_url,
                    show_all=args.all)
 


### PR DESCRIPTION
This commit fixes to handle unknown arguments. Unknown arguments should
be treated as fatal. Otherwise, users can't know their options are valid
or not at the runtime.

Fixes issue #99