### PR TITLE
Pass output to output.make_result() in stestr load

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -145,7 +145,8 @@ def load(force_init=False, in_streams=None,
     else:
         inserter = repo.get_inserter(partial=partial, run_id=run_id)
     if subunit_out:
-        output_result, summary_result = output.make_result(inserter.get_id)
+        output_result, summary_result = output.make_result(inserter.get_id,
+                                                           output=stdout)
     elif pretty_out:
         outcomes = testtools.StreamToDict(
             functools.partial(subunit_trace.show_outcome, stdout,


### PR DESCRIPTION
The stestr load command was not passing the stdout arg to the
make_result call, which is what we use to generate the subunit output.
This commit fixes this oversight and passing stdout to the function to
make sure we write the subunit output to the specified file instead of
unconditionally using sys.stdout.

Fixes Issue #115