### PR TITLE
Update travis job config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,15 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - python: "3.4.2"
-      env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.6"
       env: TOXENV=cover
-    - python: "3.5"
+    - python: "3.6"
       env: TOXENV=pep8
-    - python: "3.5"
+    - python: "3.6"
       env: TOXENV=docs
     - python: "2.7"
       env: TOXENV=py27


### PR DESCRIPTION
This commit makes some updates to the travis config to better reflect
the current state of things. First it removes the python 3.4 testing.
Most people are running this on python 3.5 or 3.6 if they're using
python3. (3.4.2 was released 3 years ago) We also don't advertise 3.4
support in the trove classifiers so there isn't any value in testing
that too. The other thing this patch does is update the non unit test
jobs to use 3.6 instead of 3.5. Since 3.6 is the latest version of
python we support we should be using that instead of 3.5.