### PR TITLE
Allow both group_regex and group-regex as an optional argument

### DIFF
--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -81,7 +81,8 @@ class StestrCLI(object):
                                  "discovery. If both this and the "
                                  "corresponding config file option are set, "
                                  "this value will be used.")
-        parser.add_argument('--group_regex', '-g', dest='group_regex',
+        parser.add_argument('--group-regex', '--group_regex', '-g',
+                            dest='group_regex',
                             default=None,
                             help="Set a group regex to use for grouping tests"
                                  " together in the stestr scheduler. If "


### PR DESCRIPTION
This commit makes to allow to use both group_regex and group-regex as an
optional argument. In all of optional arguments except this one, we use
a '-' to connect words. To keep the backward compatibility and
consistency, this commit allows both of optional arguments.