### PR TITLE
Implement quiet option for run and load commands

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -15,6 +15,7 @@
 
 import datetime
 import functools
+import os
 import sys
 import warnings
 
@@ -68,11 +69,12 @@ def get_cli_help():
 
 def run(arguments):
     args = arguments[0]
+    stdout = open(os.devnull, 'w') if args.quiet else sys.stdout
     load(repo_type=args.repo_type, repo_url=args.repo_url,
          partial=args.partial, subunit_out=args.subunit,
          force_init=args.force_init, streams=arguments[1],
          pretty_out=args.subunit_trace, color=args.color,
-         abbreviate=args.abbreviate)
+         stdout=stdout, abbreviate=args.abbreviate)
 
 
 def load(force_init=False, in_streams=None,

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -417,6 +417,7 @@ def run(arguments):
     filters = arguments[1] or None
     args = arguments[0]
     pretty_out = not args.no_subunit_trace
+    stdout = open(os.devnull, 'w') if args.quiet else sys.stdout
 
     return run_command(
         config=args.config, repo_type=args.repo_type, repo_url=args.repo_url,
@@ -430,4 +431,4 @@ def run(arguments):
         whitelist_file=args.whitelist_file, black_regex=args.black_regex,
         no_discover=args.no_discover, random=args.random, combine=args.combine,
         filters=filters, pretty_out=pretty_out, color=args.color,
-        abbreviate=args.abbreviate)
+        stdout=stdout, abbreviate=args.abbreviate)

--- a/stestr/results.py
+++ b/stestr/results.py
@@ -154,7 +154,7 @@ class CLITestResult(testtools.StreamResult):
             values.append(('skips', skips, None))
         output.output_summary(
             not bool(failures), self._summary.testsRun, num_tests_run_delta,
-            time, time_delta, values)
+            time, time_delta, values, output=self.stream)
 
     def startTestRun(self):
         super(CLITestResult, self).startTestRun()

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -73,6 +73,7 @@ class TestReturnCodes(base.TestCase):
             self.assertEqual(
                 p.returncode, expected,
                 "Stdout: %s; Stderr: %s" % (out, err))
+            return (out, err)
         else:
             self.assertEqual(p.returncode, expected,
                              "Expected return code: %s doesn't match actual "
@@ -94,6 +95,7 @@ class TestReturnCodes(base.TestCase):
             finally:
                 result.stopTestRun()
             self.assertThat(len(tests), testtools.matchers.GreaterThan(0))
+            return (out, err)
 
     def test_parallel_passing(self):
         self.assertRunExit('stestr run passing', 0)
@@ -199,3 +201,14 @@ class TestReturnCodes(base.TestCase):
         stream = self._get_cmd_stdout(
             'stestr last --subunit')[0]
         self.assertRunExit('stestr load', 0, stdin=stream)
+
+    def test_load_from_stdin_quiet(self):
+        out, err = self.assertRunExit('stestr -q run passing', 0)
+        self.assertEqual(out.decode('utf-8'), '')
+        # FIXME(masayukig): We get some warnings when we run a coverage job.
+        # So, just ignore 'err' here.
+        stream = self._get_cmd_stdout(
+            'stestr last --subunit')[0]
+        out, err = self.assertRunExit('stestr -q load', 0, stdin=stream)
+        self.assertEqual(out.decode('utf-8'), '')
+        self.assertEqual(err.decode('utf-8'), '')


### PR DESCRIPTION
This commit makes run and load commands use the quiet option. We don't
need outputs of run and load commands occasionally. So, this patch adds
the function to suppress the outputs.

We already have the quiet option, however it isn't used so far. It might
be better to move the quiet (or silent) option to load and run commands
because the option doesn't work in the other commands now.

Fixes issue #121