### PR TITLE
Use binary type for all subunit data

### DIFF
--- a/stestr/output.py
+++ b/stestr/output.py
@@ -197,7 +197,7 @@ class ReturnCodeToSubunit(object):
 
     def read(self, count=-1):
         if count == 0:
-            return six.text_type('')
+            return six.binary_type('')
         result = self.source.read(count)
         if result:
             self.lastoutput = result[-1]


### PR DESCRIPTION
In the ReturnCodeToSubunit wrapper class we process the subunit stream
input and handle non zero return codes to ensure worker failures are
tracked. However, subnit data is always binary and not a string, so we
should ensure all data we add to the stream is binary type. There was
one incorrect cast in the read() method using six.text_type() which is
the incorrect type to use. This commit fixes this by switching it to be
six.binary_type() instead.