### PR TITLE
Handle zero and negative times in stestr slowest

### DIFF
--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -38,8 +38,12 @@ def set_cli_opts(parser):
 def format_times(times):
     times = list(times)
     precision = 3
-    digits_before_point = int(
-        math.log10(times[0][1])) + 1
+    digits_before_point = 1
+    for time in times:
+        if time[1] <= 0:
+            continue
+        digits_before_point = int(math.log10(time[1])) + 1
+        break
     min_length = digits_before_point + precision + 1
 
     def format_time(time):

--- a/stestr/tests/test_slowest.py
+++ b/stestr/tests/test_slowest.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from stestr.commands import slowest
+from stestr.tests import base
+
+
+class TestSlowest(base.TestCase):
+    def test_format_times(self):
+        times = [('test_id_a', 12.34), ('test_id_b', 1.34)]
+        res = slowest.format_times(times)
+        self.assertEqual([('test_id_a', '12.340'), ('test_id_b', ' 1.340')],
+                         res)
+
+    def test_format_times_with_zero(self):
+        times = [('test_id_a', 0), ('test_id_b', 1.34)]
+        res = slowest.format_times(times)
+        self.assertEqual([('test_id_a', '0.000'), ('test_id_b', '1.340')],
+                         res)
+
+    def test_format_times_all_zero(self):
+        times = [('test_id_a', 0), ('test_id_b', 0.00)]
+        res = slowest.format_times(times)
+        self.assertEqual([('test_id_a', '0.000'), ('test_id_b', '0.000')],
+                         res)


### PR DESCRIPTION
To calculate a starting point for the column width for printing the
slowest tests table the first result was pulled from the list of test
times and the number of digits was counted. However, in the case of a
0 or negative number this doesn't work because taking a base 10 log of
that will fail. This commit address this corner case by using the first
value > 0 and if none can be found defaulting to 1 digit.