### PR TITLE
Fix typos in docs

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -162,7 +162,7 @@ colorization with subunit-trace output. If you prefer to deal with the raw
 subunit yourself and run your own output rendering or filtering you can use
 the ``--subunit`` flag to output the result stream as raw subunit v2.
 
-There is also an ``--abbreviate`` flag availble, when this is used a single
+There is also an ``--abbreviate`` flag available, when this is used a single
 character is printed for each test as it is executed. A ``.`` is printed for a
 successful test, a ``F`` for a failed test, and a ``S`` for a skipped test.
 
@@ -300,7 +300,8 @@ the stestr config file permits this. When set, tests are grouped by the group(0)
 of any regex match. Tests with no match are not grouped.
 
 For example, setting the following option in the stestr config file will group
-tests in the same class together (the last . splits the class and test method)::
+tests in the same class together (the last '.' splits the class and test
+method)::
 
     group_regex=([^\.]+\.)+
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -59,7 +59,7 @@ of these functions has a defined stable Python API signature with args and
 kwargs so that people can easily call the functions from other python programs.
 This function is what can be expected to be used outside of stestr as the stable
 interface.
-All the stable functions can be imported the the command module directly::
+All the stable functions can be imported the command module directly::
 
   from stestr import command
 

--- a/doc/source/api/test_processor.rst
+++ b/doc/source/api/test_processor.rst
@@ -3,25 +3,25 @@
 Test Processor Module
 =====================
 
-This module contains the definition of the TestListingFixture fixture class.
-This fixture is used for handling the actual spawning of worker processes
-for running tests, or listing tests. It is constructed as a `fixture`_ to
-handle the lifecycle of the test id list files which are used to pass test ids
-to the workers processes running the tests.
+This module contains the definition of the ``TestProcessorFixture`` fixture
+class. This fixture is used for handling the actual spawning of worker
+processes for running tests, or listing tests. It is constructed as a `fixture`_
+to handle the lifecycle of the test id list files which are used to pass test
+ids to the workers processes running the tests.
 
 .. _fixture: https://pypi.python.org/pypi/fixtures
 
-In the normal workflow a TestListingFixture get's returned by the
-:ref:`api_config_file`'s get_run_command() function. The config file parses the
-config file and the cli options to create a TestListingFixture with the correct
-options. This Fixture then gets returned to the CLI commands to enable them to
-run the commands.
+In the normal workflow a ``TestProcessorFixture`` get's returned by the
+:ref:`api_config_file`'s ``get_run_command()`` function. The config file parses
+the config file and the cli options to create a ``TestProcessorFixture`` with
+the correct options. This Fixture then gets returned to the CLI commands to
+enable them to run the commands.
 
-The TestListingFixture class is written to be fairly generic in the command
-it's executing. This is an artifact of being forked from testrepository where
-the test command is defined in the configuration file. In stestr the command is
-hard coded ``stestr.config_file`` module so this extra flexibility isn't really
-needed.
+The ``TestProcessorFixture`` class is written to be fairly generic in the
+command it's executing. This is an artifact of being forked from testrepository
+where the test command is defined in the configuration file. In stestr the
+command is hard coded ``stestr.config_file`` module so this extra flexibility
+isn't really needed.
 
 API Reference
 -------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,5 +23,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`search`
 


### PR DESCRIPTION
This commit fixes some typos in the docs. And this commit removes
'search' link on the index page because the page isn't rendered on the
readthedocs page[0] and we can search the docs with the search box on
the left side on every page.

[0] http://stestr.readthedocs.io/en/latest/search.html