### PR TITLE
Remove unnecessary shebang and execution bit from subunit_trace

### DIFF
--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2014 Hewlett-Packard Development Company, L.P.
 # Copyright 2014 Samsung Electronics
 # All Rights Reserved.


### PR DESCRIPTION
This subunit_trace.py was copied from os_testr[0] which has
"subunit_trace" command in it. However, stestr doesn't have that
command. So the shebang and execution bit aren't necessary. So, this
commit just removes them to keep the code simple and clean.