### PR TITLE
Fix warning message about missing worker tags in subunit-trace

### DIFF
--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -301,8 +301,7 @@ def print_summary(stream, elapsed_time):
         for w in range(max(RESULTS.keys()) + 1):
             if w not in RESULTS:
                 stream.write(
-                    " - WARNING: missing Worker %s! "
-                    "Race in testr accounting.\n" % w)
+                    " - WARNING: missing Worker %s!\n" % w)
             else:
                 num, time = worker_stats(w)
                 out_str = " - Worker %s (%s tests) => %s" % (w, num, time)


### PR DESCRIPTION
This commit fixes a small oversight in a warning message from
subunit-trace where a worker tag is not found in the output stream. This
originally was added to subunit-trace to expose a race in testrepository.
However attributing this error to testr here has 2 issues, first that
particular bug has been fixed in testrepository and the error can't ever
come from  testr in the stestr embedded copy of subunit-trace. This
attepmts to make the warning message a bit clearer if anyone ever
encounters it from stestr.