### PR TITLE
Add support for a user config file

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -354,6 +354,42 @@ There is also an option on ``stestr run``, ``--random``/``-r`` to randomize the
 order of tests as they are passed to the workers. This is useful in certain
 use cases, especially when you want to test isolation between test cases.
 
+
+User Config Files
+-----------------
+
+If you prefer to have a different default output or setting for a particular
+command stestr enables you to write a user config file to overide the defaults
+for some options on some commands. By default stestr will look for this config
+file in ``~/.stestr.yaml`` and ``~/.config/stestr.yaml`` in that order. You
+can also specify the path to a config file with the ``--user-config``
+parameter.
+
+The config file is a yaml file that has a top level key for the command and
+then a sub key for each option. For an example, a fully populated config file
+that changes the default on all available options in the config file is::
+
+    run:
+      concurrency: 42 # This can be any integer value >= 0
+      random: True
+      no-subunit-trace: True
+      color: True
+      abbreviate: True
+      slowest: True
+    failing:
+      list: True
+    last:
+      no-subunit-trace: True
+      color: True
+    load:
+      force-init: True
+      subunit-trace: True
+      color: True
+      abbreviate: True
+
+If you choose to use a user config file you can specify any subset of the
+options and commands you choose.
+
 Automated test isolation bisection
 ----------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ fixtures>=3.0.0 # Apache-2.0/BSD
 six>=1.10.0 # MIT
 testtools>=2.2.0 # MIT
 PyYAML>=3.10.0 # MIT
+voluptuous>=0.8.9 # BSD License

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -48,6 +48,11 @@ class StestrCLI(app.App):
         return parser
 
     def _set_common_opts(self, parser):
+        parser.add_argument('--user-config', dest='user_config', default=None,
+                            help='An optional path to a default user config '
+                                 'file if one is not specified ~/.stestr.yaml '
+                                 'and ~/.config/stestr.yaml will be tried in '
+                                 'that order')
         parser.add_argument('-d', '--here', dest='here',
                             help="Set the directory or url that a command "
                                  "should run from. This affects all default "

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -20,6 +20,7 @@ import testtools
 from stestr import output
 from stestr.repository import util
 from stestr import results
+from stestr import user_config
 
 
 class Failing(command.Command):
@@ -37,10 +38,15 @@ class Failing(command.Command):
         return parser
 
     def take_action(self, parsed_args):
+        user_conf = user_config.get_user_config(self.app_args.user_config)
         args = parsed_args
+        if getattr(user_conf, 'failing', False):
+            list_opt = args.list or user_conf.failing.get('list', False)
+        else:
+            list_opt = args.list
         return failing(repo_type=self.app_args.repo_type,
                        repo_url=self.app_args.repo_url,
-                       list_tests=args.list, subunit=args.subunit)
+                       list_tests=list_opt, subunit=args.subunit)
 
 
 def _show_subunit(run):

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -28,6 +28,7 @@ from stestr.repository import abstract as repository
 from stestr.repository import util
 from stestr import results
 from stestr import subunit_trace
+from stestr import user_config
 from stestr import utils
 
 
@@ -73,15 +74,29 @@ class Load(command.Command):
         return help_str
 
     def take_action(self, parsed_args):
+        user_conf = user_config.get_user_config(self.app_args.user_config)
         args = parsed_args
+        if getattr(user_conf, 'load', False):
+            force_init = args.force_init or user_conf.load.get('force-init',
+                                                               False)
+            pretty_out = args.subunit_trace or user_conf.load.get(
+                'subunit-trace', False)
+            color = args.color or user_conf.load.get('color', False)
+            abbreviate = args.abbreviate or user_conf.load.get('abbreviate',
+                                                               False)
+        else:
+            force_init = args.force_init
+            pretty_out = args.subunit_trace
+            color = args.color
+            abbreviate = args.abbreviate
         verbose_level = self.app.options.verbose_level
         stdout = open(os.devnull, 'w') if verbose_level == 0 else sys.stdout
         load(repo_type=self.app_args.repo_type,
              repo_url=self.app_args.repo_url,
              partial=args.partial, subunit_out=args.subunit,
-             force_init=args.force_init, streams=args.files,
-             pretty_out=args.subunit_trace, color=args.color,
-             stdout=stdout, abbreviate=args.abbreviate)
+             force_init=force_init, streams=args.files,
+             pretty_out=pretty_out, color=color,
+             stdout=stdout, abbreviate=abbreviate)
 
 
 def load(force_init=False, in_streams=None,

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -1,0 +1,193 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+
+import mock
+import six
+
+from stestr.tests import base
+from stestr import user_config
+
+FULL_YAML = """
+run:
+  concurrency: 42 # This can be any integer value
+  random: True
+  no-subunit-trace: True
+  color: True
+  abbreviate: True
+  slowest: True
+failing:
+  list: True
+last:
+  no-subunit-trace: True
+  color: True
+load:
+  force-init: True
+  subunit-trace: True
+  color: True
+  abbreviate: True
+"""
+
+INVALID_YAML_FIELD = """
+run:
+  color: True,
+"""
+
+YAML_NOT_INT = """
+run:
+  concurrency: Two
+"""
+
+
+class TestUserConfig(base.TestCase):
+
+    def setUp(self):
+        super(TestUserConfig, self).setUp()
+        home_dir = os.path.expanduser("~")
+        self.xdg_path = os.path.join(os.path.join(home_dir, '.config'),
+                                     'stestr.yaml')
+        self.home_path = os.path.join(home_dir, '.stestr.yaml')
+
+    @mock.patch('sys.exit')
+    @mock.patch('stestr.user_config.UserConfig')
+    def test_get_user_config_invalid_path(self, user_mock, exit_mock):
+        user_config.get_user_config('/i_am_an_invalid_path')
+        exit_mock.assert_called_once_with(1)
+
+    @mock.patch('os.path.isfile')
+    @mock.patch('stestr.user_config.UserConfig')
+    def test_get_user_config_xdg_file(self, user_mock, path_mock):
+
+        def fake_isfile(path):
+            if path == self.xdg_path:
+                return True
+            else:
+                return False
+
+        path_mock.side_effect = fake_isfile
+        user_config.get_user_config()
+        user_mock.assert_called_once_with(self.xdg_path)
+
+    @mock.patch('os.path.isfile')
+    @mock.patch('stestr.user_config.UserConfig')
+    def test_get_default_user_config_file(self, user_mock, path_mock):
+
+        def fake_isfile(path):
+            if path == self.home_path:
+                return True
+            else:
+                return False
+
+        path_mock.side_effect = fake_isfile
+        user_config.get_user_config()
+        user_mock.assert_called_once_with(self.home_path)
+
+    @mock.patch('yaml.load', return_value={})
+    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    def test_user_config_empty_schema(self, yaml_mock):
+        user_conf = user_config.UserConfig('/path')
+        self.assertEqual({}, user_conf.config)
+
+    def _restore_stdout(self, old_out):
+        sys.stdout = old_out
+
+    @mock.patch('yaml.load', return_value={'init': {'subunit-trace': True}})
+    @mock.patch('sys.exit')
+    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    def test_user_config_invalid_command(self, exit_mock, yaml_mock):
+
+        temp_out = sys.stdout
+        std_out = six.StringIO()
+        sys.stdout = std_out
+        self.addCleanup(self._restore_stdout, temp_out)
+        user_config.UserConfig('/path')
+        exit_mock.assert_called_once_with(1)
+        error_string = ("Provided user config file /path is invalid because:\n"
+                        "extra keys not allowed @ data['init']")
+        std_out.seek(0)
+        self.assertEqual(error_string, std_out.read().rstrip())
+
+    @mock.patch('yaml.load', return_value={'run': {'subunit-trace': True}})
+    @mock.patch('sys.exit')
+    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    def test_user_config_invalid_option(self, exit_mock, yaml_mock):
+
+        temp_out = sys.stdout
+        std_out = six.StringIO()
+        sys.stdout = std_out
+        self.addCleanup(self._restore_stdout, temp_out)
+        user_config.UserConfig('/path')
+        exit_mock.assert_called_once_with(1)
+        error_string = ("Provided user config file /path is invalid because:\n"
+                        "extra keys not allowed @ "
+                        "data['run']['subunit-trace']")
+        std_out.seek(0)
+        self.assertEqual(error_string, std_out.read().rstrip())
+
+    @mock.patch('six.moves.builtins.open',
+                return_value=six.StringIO(FULL_YAML))
+    def test_user_config_full_config(self, open_mock):
+        user_conf = user_config.UserConfig('/path')
+        full_dict = {
+            'run': {
+                'concurrency': 42,
+                'random': True,
+                'no-subunit-trace': True,
+                'color': True,
+                'abbreviate': True,
+                'slowest': True},
+            'failing': {
+                'list': True},
+            'last': {
+                'no-subunit-trace': True,
+                'color': True},
+            'load': {
+                'force-init': True,
+                'subunit-trace': True,
+                'color': True,
+                'abbreviate': True}
+        }
+        self.assertEqual(full_dict, user_conf.config)
+
+    @mock.patch('sys.exit')
+    @mock.patch('six.moves.builtins.open',
+                return_value=six.StringIO(INVALID_YAML_FIELD))
+    def test_user_config_invalid_value_type(self, open_mock, exit_mock):
+        temp_out = sys.stdout
+        std_out = six.StringIO()
+        sys.stdout = std_out
+        self.addCleanup(self._restore_stdout, temp_out)
+        user_config.UserConfig('/path')
+        exit_mock.assert_called_once_with(1)
+        error_string = ("Provided user config file /path is invalid because:\n"
+                        "expected bool for dictionary value @ "
+                        "data['run']['color']")
+        std_out.seek(0)
+        self.assertEqual(error_string, std_out.read().rstrip())
+
+    @mock.patch('sys.exit')
+    @mock.patch('six.moves.builtins.open',
+                return_value=six.StringIO(YAML_NOT_INT))
+    def test_user_config_invalid_integer(self, open_mock, exit_mock):
+        temp_out = sys.stdout
+        std_out = six.StringIO()
+        sys.stdout = std_out
+        self.addCleanup(self._restore_stdout, temp_out)
+        user_config.UserConfig('/path')
+        exit_mock.assert_called_once_with(1)
+        error_string = ("Provided user config file /path is invalid because:\n"
+                        "expected int for dictionary value @ "
+                        "data['run']['concurrency']")
+        std_out.seek(0)
+        self.assertEqual(error_string, std_out.read().rstrip())

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+
+import voluptuous as vp
+import yaml
+
+
+def get_user_config(path=None):
+    if not path:
+        home_dir = os.path.expanduser("~")
+        path = os.path.join(home_dir, '.stestr.yaml')
+        if not os.path.isfile(path):
+            path = os.path.join(os.path.join(home_dir, '.config'),
+                                'stestr.yaml')
+            if not os.path.isfile(path):
+                path = None
+        if not path:
+            return None
+    else:
+        if not os.path.isfile(path):
+            msg = 'The specified stestr user config is not a valid path'
+            print(msg)
+            sys.exit(1)
+
+    return UserConfig(path)
+
+
+class UserConfig(object):
+
+    def __init__(self, path):
+        self.schema = vp.Schema({
+            vp.Optional('run'): {
+                vp.Optional('concurrency'): int,
+                vp.Optional('random'): bool,
+                vp.Optional('no-subunit-trace'): bool,
+                vp.Optional('color'): bool,
+                vp.Optional('abbreviate'): bool,
+                vp.Optional('slowest'): bool,
+            },
+            vp.Optional('failing'): {
+                vp.Optional('list'): bool,
+            },
+            vp.Optional('last'): {
+                vp.Optional('no-subunit-trace'): bool,
+                vp.Optional('color'): bool,
+            },
+            vp.Optional('load'): {
+                vp.Optional('force-init'): bool,
+                vp.Optional('subunit-trace'): bool,
+                vp.Optional('color'): bool,
+                vp.Optional('abbreviate'): bool,
+            }
+        })
+        self.config = yaml.load(open(path, 'r').read())
+        try:
+            self.schema(self.config)
+        except vp.MultipleInvalid as e:
+            msg = 'Provided user config file %s is invalid because:\n%s' % (
+                path, str(e))
+            print(msg)
+            sys.exit(1)
+
+    @property
+    def run(self):
+        return self.config.get('run')
+
+    @property
+    def failing(self):
+        return self.config.get('failing')
+
+    @property
+    def last(self):
+        return self.config.get('last')
+
+    @property
+    def load(self):
+        return self.config.get('load')


### PR DESCRIPTION
This commit adds a new feature, the user config file. This enables users
to write a global config file for UI preferences on certain commands
that will be the new default for that option. For example, if you prefer
the default output on the 'stestr run' command to be with the
--no-subunit-trace flag set. You can just write a user config file to
set this output. Then for all stestr run invocations the default output
will be with --no-subunit-trace set.