### PR TITLE
Fix no attribute 'repo_type' error when running w/ --slowest option

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -184,7 +184,8 @@ class Run(command.Command):
         if getattr(user_conf, 'run', False):
             user_slowest = user_conf.run.get('slowest', False)
         if args.slowest or user_slowest:
-            slowest.slowest(repo_type=args.repo_type, repo_url=args.repo_url)
+            slowest.slowest(repo_type=self.app_args.repo_type,
+                            repo_url=self.app_args.repo_url)
 
         return result
 

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -152,6 +152,12 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run --subunit passing', 0,
                            subunit=True)
 
+    def test_slowest_passing(self):
+        self.assertRunExit('stestr run --slowest passing', 0)
+
+    def test_slowest_failing(self):
+        self.assertRunExit('stestr run --slowest failing', 1)
+
     def test_until_failure_fails(self):
         self.assertRunExit('stestr run --until-failure', 1)
 


### PR DESCRIPTION
This commit fixes the issue "no attribute `repo_type` error when
running with `--slowest` option. We have neither `repo_type` nor
`repo_url` in `args` but `self.app_args`.

Fixes Issue #140