### PR TITLE
Update the package summary in setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stestr
-summary = A test runner runner similar to testrepository
+summary =  A parallel Python test runner built around subunit
 description-file =
     README.rst
 author = Matthew Treinish


### PR DESCRIPTION
This commit updates the description of the stestr package. The one in
setup.cfg is quite old back from when we were still deciding on the
scope of the project. We have since updated the descriptions everywhere
else to explain the scope of the project. The setup.cfg summary is what
gets sent to pypi: https://pypi.python.org/pypi/stestr/2.0.0 so we
should update this to make sure it reflects the current scope of the
project more accurately.