### PR TITLE
Add alt texts for badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,15 +3,19 @@ Slim/Super Test Repository
 
 .. image:: https://img.shields.io/travis/mtreinish/stestr/master.svg?style=flat-square
     :target: https://travis-ci.org/mtreinish/stestr
+    :alt: Build status
 
 .. image:: https://img.shields.io/appveyor/ci/mtreinish/stestr/master.svg?logo=appveyor&style=flat-square
     :target: https://ci.appveyor.com/project/mtreinish/stestr
+    :alt: Appveyor build status
 
 .. image:: https://img.shields.io/coveralls/github/mtreinish/stestr/master.svg?style=flat-square
     :target: https://coveralls.io/github/mtreinish/stestr?branch=master
+    :alt: Code coverage
 
 .. image:: https://img.shields.io/pypi/v/stestr.svg?style=flat-square
     :target: https://pypi.python.org/pypi/stestr
+    :alt: Latest Version
 
 You can see the full rendered docs at: http://stestr.readthedocs.io/en/latest/
 


### PR DESCRIPTION
This commit adds alt texts for the badges in README. This would be
useful when the images can't be shown due to such as network issues, on a text browser, etc.