### PR TITLE
Fix the manual docs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ running a single test (or module) and want to avoid the overhead of doing test
 discovery you can use the ``--no-discover``/``-n`` option.
 
 For all the details on these commands and more thorough explanation of options
-see the :ref:`manual`.
+see the stestr manual: https://stestr.readthedocs.io/en/latest/MANUAL.html
 
 Migrating from testrepository
 -----------------------------


### PR DESCRIPTION
The stestr README used to include a previous link to the stestr manual
page. This was done using sphinx internal refs, because in a
sphinx doc build this is the cleanest way. However, on github the README
is not rendered using sphinx, it just parses the rst directly and
converts that to html. This means we would have a link that didn't work.
To fix the rendered html output on github this changes that link to just
be an http link to the read the docs page for the stestr manual.