### PR TITLE
Add usage to manual docs page

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -3,6 +3,15 @@
 stestr user manual
 ==================
 
+Usage
+-----
+
+.. autoprogram-cliff:: stestr.cli.StestrCLI
+   :application: stestr
+
+.. autoprogram-cliff:: stestr.cm
+   :application: stestr
+
 Overview
 --------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,6 +27,7 @@ import sys, os
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode',
+              'cliff.sphinxext',
              ]
 
 # Enable todos in the output


### PR DESCRIPTION
This commit leverages the cliff autoprogram documentation sphinx to add
usage sections for each command to the beginning of the stestr manual.
This is a standard thing to list out each option in the cli which we
were missing from the docs. Luckily cliff provides an interface to
generate this so we don't have to write it out manually.