### PR TITLE
Add an issue template to project

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,18 @@
+### Issue description
+
+Include a description of the issue encountered, and what the expected behavior
+was. Also include any configuration, test suite, or other relevant information
+to reproduce the issue.
+
+Note if you encounter an error message try to re-run the command with --debug to print any tracebacks
+
+### System information
+
+**stestr version (`stestr --version`):**
+
+**Python release (`python --version`):**
+
+**pip packages (`pip freeze`):**
+
+
+### Additional information


### PR DESCRIPTION
While most of the bugs have been filed by the project maintainers it
still good to provide a template on some commonly needed information to
triage bugs. Especially including a note about --debug which is needed
to capture tracebacks.