### PR TITLE
Fix manpage generation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -219,7 +219,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'stestr', u'stestr Documentation',
+    ('MANUAL', 'stestr',
+     u'A parallel Python test runner built around subunit',
      [u'Matthew Treinish'], 1)
 ]
 


### PR DESCRIPTION
When using sphinx to generate a man page for stestr it was building a
man page out of all the docs in stestr. This worked fine but made a
pretty bad man page. The MANUAL.rst file is meant to be both an HTML
manual for using stestr and also would make a good man page. This commit
adjusts the root doc for manpage generation to be MANUAL.rst instead of
index.rst. This results in a much more sane manpage when running a
command like:

sphinx-build -b man doc/source doc/build/man