### PR TITLE
Cap PBR<4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 future
-pbr!=2.1.0,>=2.0.0 # Apache-2.0
+pbr!=2.1.0,>=2.0.0,<4.0.0 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=0.18.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=2.0.0'],
+    setup_requires=['pbr>=2.0.0,<4.0.0'],
     pbr=True)


### PR DESCRIPTION
The PBR 4.0.0 release introduced a regression for windows .exe
generation [1]. This breaks the CI jobs in appveyor to verify things
still work on windows. To resolve this issue until there is a working
pbr release this commit caps the version we use to be < 4.0.0.

[1] https://bugs.launchpad.net/pbr/+bug/1761134