### PR TITLE
Add option to suppress attachment printing on successful tests

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -385,16 +385,19 @@ that changes the default on all available options in the config file is::
       color: True
       abbreviate: True
       slowest: True
+      suppress-attachments: True
     failing:
       list: True
     last:
       no-subunit-trace: True
       color: True
+      suppress-attachments: True
     load:
       force-init: True
       subunit-trace: True
       color: True
       abbreviate: True
+      suppress-attachments: True
 
 If you choose to use a user config file you can specify any subset of the
 options and commands you choose.

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -151,7 +151,7 @@ def find_test_run_time_diff(test_id, run_time):
 
 def show_outcome(stream, test, print_failures=False, failonly=False,
                  enable_diff=False, threshold='0', abbreviate=False,
-                 enable_color=False):
+                 enable_color=False, suppress_attachments=False):
     global RESULTS
     status = test['status']
     # TODO(sdague): ask lifeless why on this?
@@ -205,7 +205,8 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
                 stream.write(out_string + '] ... ')
                 color.write('ok', 'green')
                 stream.write('\n')
-                print_attachments(stream, test)
+                if not suppress_attachments:
+                    print_attachments(stream, test)
         elif status == 'skip':
             if abbreviate:
                 color.write('S', 'blue')
@@ -349,7 +350,7 @@ def parse_args():
 
 def trace(stdin, stdout, print_failures=False, failonly=False,
           enable_diff=False, abbreviate=False, color=False, post_fails=False,
-          no_summary=False):
+          no_summary=False, suppress_attachments=False):
     stream = subunit.ByteStreamToStreamResult(
         stdin, non_subunit_name='stdout')
     outcomes = testtools.StreamToDict(
@@ -358,7 +359,8 @@ def trace(stdin, stdout, print_failures=False, failonly=False,
                           failonly=failonly,
                           enable_diff=enable_diff,
                           abbreviate=abbreviate,
-                          enable_color=color))
+                          enable_color=color,
+                          suppress_attachments=suppress_attachments))
     summary = testtools.StreamSummary()
     result = testtools.CopyStreamResult([outcomes, summary])
     result = testtools.StreamResultRouter(result)

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -28,16 +28,19 @@ run:
   color: True
   abbreviate: True
   slowest: True
+  suppress-attachments: True
 failing:
   list: True
 last:
   no-subunit-trace: True
   color: True
+  suppress-attachments: True
 load:
   force-init: True
   subunit-trace: True
   color: True
   abbreviate: True
+  suppress-attachments: True
 """
 
 INVALID_YAML_FIELD = """
@@ -147,17 +150,20 @@ class TestUserConfig(base.TestCase):
                 'no-subunit-trace': True,
                 'color': True,
                 'abbreviate': True,
-                'slowest': True},
+                'slowest': True,
+                'suppress-attachments': True},
             'failing': {
                 'list': True},
             'last': {
                 'no-subunit-trace': True,
-                'color': True},
+                'color': True,
+                'suppress-attachments': True},
             'load': {
                 'force-init': True,
                 'subunit-trace': True,
                 'color': True,
-                'abbreviate': True}
+                'abbreviate': True,
+                'suppress-attachments': True}
         }
         self.assertEqual(full_dict, user_conf.config)
 

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -48,6 +48,7 @@ class UserConfig(object):
                 vp.Optional('color'): bool,
                 vp.Optional('abbreviate'): bool,
                 vp.Optional('slowest'): bool,
+                vp.Optional('suppress-attachments'): bool,
             },
             vp.Optional('failing'): {
                 vp.Optional('list'): bool,
@@ -55,12 +56,14 @@ class UserConfig(object):
             vp.Optional('last'): {
                 vp.Optional('no-subunit-trace'): bool,
                 vp.Optional('color'): bool,
+                vp.Optional('suppress-attachments'): bool,
             },
             vp.Optional('load'): {
                 vp.Optional('force-init'): bool,
                 vp.Optional('subunit-trace'): bool,
                 vp.Optional('color'): bool,
                 vp.Optional('abbreviate'): bool,
+                vp.Optional('suppress-attachments'): bool,
             }
         })
         with open(path, 'r') as fd:


### PR DESCRIPTION
This commit adds a new cli and user_config option to suppress printing
attachments on successful test runs. Originally in subunit_trace stdout
and stderr were unconditionally printed on test success because the
theory was this was expected to be inadvertent and likely a bug so end
users would want to know if their tests were writing to to either
stream. However, this was a faulty assumption in that some test suites
write to either during normal operation and writing the contents on test
success is just polluting the output of a test run. Therefore this adds
an option to let the user configure this functionality to address that
use case.