### PR TITLE
Cap pip version in windows ci

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   - ECHO "Installed SDKs:"
   - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
 
- # Install Python (from the official .msi of http://python.org) and pip when
+  # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.
   - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
 
@@ -50,7 +50,9 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  # NOTE(mtreinish): Because of bugs in pip>=10.0.0 preventing pip from working
+  # we're capping pip here
+  - "pip install --disable-pip-version-check --user --upgrade pip<10.0.0"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,


### PR DESCRIPTION
Running pip>=10.0.0 in the windows ci is failing and blocking changes.
This commit is to workaround this issue, #165, until the upstream
pypa/pip#5223 (or equivalent bug) is fixed in another pip release by
capping pip to be <10.0.0.