### PR TITLE
Ignore errors on cleanup in test_return_codes

### DIFF
--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -36,7 +36,7 @@ class TestReturnCodes(base.TestCase):
         super(TestReturnCodes, self).setUp()
         # Setup test dirs
         self.directory = tempfile.mkdtemp(prefix='stestr-unit')
-        self.addCleanup(shutil.rmtree, self.directory)
+        self.addCleanup(shutil.rmtree, self.directory, ignore_errors=True)
         self.test_dir = os.path.join(self.directory, 'tests')
         os.mkdir(self.test_dir)
         # Setup Test files


### PR DESCRIPTION
This commit is an attempt to mitigate #162 where the temp directory
removal is failing on windows CI occasionally. This commit sets the
ignore_errors flag on the shutil.rmtree() call which makes any errors
encountered not fatal. While this isn't ideal because it could result
in leaking the temp directories on test runs. But, since we haven't
encountered this failure on any operating system or environment
besides the windows CI in appveyor the risk of that weighed against
the nondeterministic failures blocking changes minimizes that concern.