### PR TITLE
Switch python doc reference from 2 to 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ which just tells stestr the relative path for the directory to use for
 test discovery. This is the same as ``--start-directory`` in the standard
 `unittest discovery`_
 
-.. _unittest discovery: https://docs.python.org/2.7/library/unittest.html#test-discovery
+.. _unittest discovery: https://docs.python.org/3/library/unittest.html#test-discovery
 
 After this file is created you should be all set to start using stestr to run
 tests. You can create a repository for test results with the stestr init

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -52,7 +52,7 @@ to ``./``. It's also worth noting that shell variables for these 2 config
 options (and only these 2 options) are expanded on platforms that have a shell.
 This enables you to have conditional discovery paths based on your environment.
 
-.. _unittest discovery: https://docs.python.org/2/library/unittest.html#test-discovery
+.. _unittest discovery: https://docs.python.org/3/library/unittest.html#test-discovery
 
 For example, having a config file like::
 

--- a/doc/source/internal_arch.rst
+++ b/doc/source/internal_arch.rst
@@ -49,7 +49,7 @@ parser object passed into it. The intent of this function is to have any command
 specific arguments defined on the provided parser object by calling
 `parser.add_argument()`_ for each argument.
 
-.. _parser.add_argument(): https://docs.python.org/2/library/argparse.html#the-add-argument-method
+.. _parser.add_argument(): https://docs.python.org/3/library/argparse.html#the-add-argument-method
 
 get_description()
 '''''''''''''''''


### PR DESCRIPTION
This commit makes the URLs of the python docs switch from version 2 to
version 3. We should point to the latest version documents as
possible if there is no particular reason.