### PR TITLE
Remove Python 2.6 code

### DIFF
--- a/stestr/output.py
+++ b/stestr/output.py
@@ -74,10 +74,7 @@ def output_tests(tests, output=sys.stdout):
     """
 
     for test in tests:
-        # On Python 2.6 id() returns bytes.
         id_str = test.id()
-        if type(id_str) is bytes:
-            id_str = id_str.decode('utf8')
         output.write(id_str)
         output.write(six.text_type('\n'))
 


### PR DESCRIPTION
This commit removes the code for Python 2.6 version. We don't test
stestr on Python 2.6 and we also declare the versions only 3.6, 3.5
and 2.7 in setup.cfg. So, we don't need to have this code anymore.