### PR TITLE
Clarify docs on group_regex

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -319,10 +319,11 @@ And then find tests with that tag::
 Grouping Tests
 --------------
 
-In certain scenarios you may want to group tests of a certain type together
-so that they will be run by the same worker process. The group_regex option in
-the stestr config file permits this. When set, tests are grouped by the group(0)
-of any regex match. Tests with no match are not grouped.
+In certain scenarios you may want to group tests of a certain type together so
+that they will be run by the same worker process. The ``group_regex`` option in
+the stestr config file permits this. When set, tests are grouped by the entire
+matching portion of the regex. The match must begin at the start of the string.
+Tests with no match are not grouped.
 
 For example, setting the following option in the stestr config file will group
 tests in the same class together (the last '.' splits the class and test


### PR DESCRIPTION
Interpreting the manual section about Grouping Tests required
remembering that match() only matches at the start of a string; and that
group(0) is the entire matching portion of the regex, not the first
group. State this explicitly instead.