### PR TITLE
Really uncap pbr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 future
-pbr!=2.1.0,>=2.0.0,<4.0.0 # Apache-2.0
+pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.3.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=2.0.0,<4.0.0'],
+    setup_requires=['pbr>=2.0.0'],
     pbr=True)


### PR DESCRIPTION
The previous commit attempted to uncap pbr to see if the windows issue
was addressed. But neglected to do so in the setup.py cap in addition to
the requirements file. This commit corrects the oversight and uncaps
that too.