### PR TITLE
Revert "Uncap pbr"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 future
-pbr!=2.1.0,>=2.0.0 # Apache-2.0
+pbr!=2.1.0,>=2.0.0,<4.0.0 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.3.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD


### PR DESCRIPTION
Reverts mtreinish/stestr#173

This was only a partial uncap as it was still capped in the setup.py for stestr. Meaning the passing tests were still using pbr<4.0.0. When you uncap the setup.py too, like in #174, things start failing again. The underlying issue hasn't been addressed yet so we can't uncap the requirement yet.