### PR TITLE
Fix description for the stestr run command

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -133,8 +133,8 @@ class Run(command.Command):
         return parser
 
     def get_description(self):
-        help_str = "Run the tests for a project and load them into a "
-        "repository."
+        help_str = (
+            "Run the tests for a project and store them into the repository.")
         return help_str
 
     def take_action(self, parsed_args):


### PR DESCRIPTION
The description for the run command being returned by the
get_description() function was truncated because the string was split
over multiple lines. However, the split was done incorrectly and the
second part wasn't being set. This commit corrects the oversight so the
description is complete in the documentation and --help.