### PR TITLE
Allow stestr to be called as a module

### DIFF
--- a/stestr/__main__.py
+++ b/stestr/__main__.py
@@ -1,0 +1,6 @@
+import sys
+from stestr.cli import main
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Enable standard python module callling via:
python -m stestr ...

This gets stestr calling method in-line with most of other
python tools which allow this (pip, tox, flake8, ...)

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>