### PR TITLE
WIP: Fix unxsuccess return code

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -110,6 +110,12 @@ class Load(command.Command):
              suppress_attachments=suppress_attachments)
 
 
+def _real_successful(result):
+    if result.unexpectedSuccesses or result.failures or result.errors:
+        return False
+    return True
+
+
 def load(force_init=False, in_streams=None,
          partial=False, subunit_out=False, repo_type='file', repo_url=None,
          run_id=None, streams=None, pretty_out=False, color=False,
@@ -219,7 +225,8 @@ def load(force_init=False, in_streams=None,
     if pretty_out and not subunit_out:
         subunit_trace.print_fails(stdout)
         subunit_trace.print_summary(stdout, elapsed_time)
-    if not summary_result.wasSuccessful():
+    if (not summary_result.wasSuccessful() and
+        not _real_successful(summary_result)):
         return 1
     else:
         return 0

--- a/stestr/tests/files/failing-tests
+++ b/stestr/tests/files/failing-tests
@@ -21,3 +21,7 @@ class FakeTestClass(testtools.TestCase):
     def test_pass_list(self):
         test_list = ['test', 'a', 'b']
         self.assertIn('fail', test_list)
+
+    def test_pass_unxsuccess(self):
+       self.expectFailure("we are sad",
+                          self.assertEqual, 1, 1)

--- a/stestr/tests/files/passing-tests
+++ b/stestr/tests/files/passing-tests
@@ -21,3 +21,7 @@ class FakeTestClass(testtools.TestCase):
     def test_pass_list(self):
         test_list = ['test', 'a', 'b']
         self.assertIn('test', test_list)
+
+    def test_pass_xfail(self):
+       self.expectFailure("we are sad",
+                          self.assertEqual, 1, 0)

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -121,6 +121,12 @@ class TestReturnCodes(base.TestCase):
     def test_parallel_passing(self):
         self.assertRunExit('stestr run passing', 0)
 
+    def test_parallel_passing_xfail(self):
+        self.assertRunExit('stestr run xfail', 0)
+
+    def test_parallel_fails_unxsuccess(self):
+        self.assertRunExit('stestr run unxsuccess', 1)
+
     def test_parallel_passing_bad_regex(self):
         self.assertRunExit('stestr run bad.regex.foobar', 1)
 
@@ -148,6 +154,12 @@ class TestReturnCodes(base.TestCase):
 
     def test_serial_fails(self):
         self.assertRunExit('stestr run --serial', 1)
+
+    def test_serial_passing_xfail(self):
+        self.assertRunExit('stestr run --serial xfail', 0)
+
+    def test_serial_fails_unxsuccess(self):
+        self.assertRunExit('stestr run --serial unxsuccess', 1)
 
     def test_serial_blacklist(self):
         fd, path = tempfile.mkstemp()


### PR DESCRIPTION
This is a first attempt to fix unxsuccess. It doesn't quite work, my
guess is because likely the test result is properly tracking the
unxsuccess tests and thus the list is empty when it's manually checked.