### PR TITLE
Add support for test class and method by path on no-discover

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -100,6 +100,14 @@ import paths) For example::
 will also bypass discovery and directly call subunit.run on the module
 specified.
 
+Additionally you can specify a specific class or method within that file using
+``::`` to specify a class and method. For example::
+
+  $ stestr run --no-discover project/tests/test_foo.py::TestFoo::test_method
+
+will skip discovery and directly call subunit.run on the test method in the
+specified test class.
+
 Test Selection
 --------------
 

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -313,8 +313,10 @@ def run_command(config='.stestr.conf', repo_type='file',
         combine_id = six.text_type(latest_id)
     if no_discover:
         ids = no_discover
+        if '::' in ids:
+            ids = ids.replace('::', '.')
         if ids.find('/') != -1:
-            root, _ = os.path.splitext(ids)
+            root = ids.replace('.py', '')
             ids = root.replace('/', '.')
         run_cmd = 'python -m subunit.run ' + ids
 

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -314,3 +314,33 @@ class TestReturnCodes(base.TestCase):
         stdout = fixtures.StringStream('stdout')
         self.useFixture(stdout)
         self.assertEqual(0, list_cmd.list_command(stdout=stdout.stream))
+
+    def test_run_no_discover_pytest_path(self):
+        passing_string = 'tests/test_passing.py::FakeTestClass::test_pass_list'
+        out, err = self.assertRunExit('stestr run -n %s' % passing_string, 0)
+        lines = out.decode('utf8').splitlines()
+        self.assertIn(' - Passed: 1', lines)
+        self.assertIn(' - Failed: 0', lines)
+
+    def test_run_no_discover_pytest_path_failing(self):
+        passing_string = 'tests/test_failing.py::FakeTestClass::test_pass_list'
+        out, err = self.assertRunExit('stestr run -n %s' % passing_string, 1)
+        lines = out.decode('utf8').splitlines()
+        self.assertIn(' - Passed: 0', lines)
+        self.assertIn(' - Failed: 1', lines)
+
+    def test_run_no_discover_file_path(self):
+        passing_string = 'tests/test_passing.py'
+        out, err = self.assertRunExit('stestr run -n %s' % passing_string, 0)
+        lines = out.decode('utf8').splitlines()
+        self.assertIn(' - Passed: 2', lines)
+        self.assertIn(' - Failed: 0', lines)
+        self.assertIn(' - Expected Fail: 1', lines)
+
+    def test_run_no_discover_file_path_failing(self):
+        passing_string = 'tests/test_failing.py'
+        out, err = self.assertRunExit('stestr run -n %s' % passing_string, 1)
+        lines = out.decode('utf8').splitlines()
+        self.assertIn(' - Passed: 0', lines)
+        self.assertIn(' - Failed: 2', lines)
+        self.assertIn(' - Unexpected Success: 1', lines)


### PR DESCRIPTION
This commit adds support to the --no-discover/-n flag on stestr run for
specifying a test class and test method when passing in a filepath. This
borrows the syntax from pytest so you use '::' to specify a class and
then method. For example 'path/test_mod.py::TestClassA::test_method_b'
would be used to run only test_method_b in the TestClassA test case in
the path/test_mod.py file.

Fixes #180