### PR TITLE
Use reported times instead of wall time in subunit-trace

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -13,7 +13,6 @@
 """Load data into a repository."""
 
 
-import datetime
 import functools
 import os
 import sys
@@ -208,15 +207,22 @@ def load(force_init=False, in_streams=None,
             inserter.get_id, stdout, previous_run)
         summary_result = output_result.get_summary()
     result = testtools.CopyStreamResult([inserter, output_result])
-    start_time = datetime.datetime.utcnow()
     result.startTestRun()
     try:
         case.run(result)
     finally:
         result.stopTestRun()
-    stop_time = datetime.datetime.utcnow()
-    elapsed_time = stop_time - start_time
     if pretty_out and not subunit_out:
+        start_times = []
+        stop_times = []
+        for worker in subunit_trace.RESULTS:
+            start_times += [
+                x['timestamps'][0] for x in subunit_trace.RESULTS[worker]]
+            stop_times += [
+                x['timestamps'][1] for x in subunit_trace.RESULTS[worker]]
+        start_time = min(start_times)
+        stop_time = max(stop_times)
+        elapsed_time = stop_time - start_time
         subunit_trace.print_fails(stdout)
         subunit_trace.print_summary(stdout, elapsed_time)
     if not results.wasSuccessful(summary_result):

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import argparse
-import datetime
 import functools
 import os
 import re
@@ -368,13 +367,18 @@ def trace(stdin, stdout, print_failures=False, failonly=False,
     result = testtools.StreamResultRouter(result)
     cat = subunit.test_results.CatFiles(stdout)
     result.add_rule(cat, 'test_id', test_id=None)
-    start_time = datetime.datetime.utcnow()
     result.startTestRun()
     try:
         stream.run(result)
     finally:
         result.stopTestRun()
-    stop_time = datetime.datetime.utcnow()
+    start_times = []
+    stop_times = []
+    for worker in RESULTS:
+        start_times += [x['timestamps'][0] for x in RESULTS[worker]]
+        stop_times += [x['timestamps'][1] for x in RESULTS[worker]]
+    start_time = min(start_times)
+    stop_time = max(stop_times)
     elapsed_time = stop_time - start_time
 
     if count_tests('status', '.*') == 0:


### PR DESCRIPTION
This commit updates the subunit_trace module to leverage the timestamps
reported in the subunit instead of the wall time for the elapsed time
output. When we were using the wall time if we were just reading a
subunit file this would be the time it took to read an process the
subunit data. Which is not the actual run time of the test. By switching
to use the elapsed time between the first start timestamp and the last
stop timestamp we'll always get an accurate value. This does come with
the tradeoff of not counting any setUp before the start time or
tearDown/cleanUp after the last test, since that data isn't in the
subunit stream. But that feels like a worthwhile compromise for having
moderately accurate numbers all the time.

Fixes #119