### PR TITLE
Make test running serially when just loading

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -106,13 +106,14 @@ class Load(command.Command):
              force_init=force_init, streams=args.files,
              pretty_out=pretty_out, color=color,
              stdout=stdout, abbreviate=abbreviate,
-             suppress_attachments=suppress_attachments)
+             suppress_attachments=suppress_attachments, serial=True)
 
 
 def load(force_init=False, in_streams=None,
          partial=False, subunit_out=False, repo_type='file', repo_url=None,
          run_id=None, streams=None, pretty_out=False, color=False,
-         stdout=sys.stdout, abbreviate=False, suppress_attachments=False):
+         stdout=sys.stdout, abbreviate=False, suppress_attachments=False,
+         serial=False):
     """Load subunit streams into a repository
 
     This function will load subunit streams into the repository. It will
@@ -180,7 +181,13 @@ def load(force_init=False, in_streams=None,
             case = testtools.DecorateTestCaseResult(case, decorate)
             yield (case, str(pos))
 
-    case = testtools.ConcurrentStreamTestSuite(make_tests)
+    if serial:
+        for _, stream in enumerate(streams):
+            # Calls StreamResult API.
+            case = subunit.ByteStreamToStreamResult(
+                stream, non_subunit_name='stdout')
+    else:
+        case = testtools.ConcurrentStreamTestSuite(make_tests)
     if not run_id:
         inserter = repo.get_inserter()
     else:

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -191,12 +191,13 @@ def load(force_init=False, in_streams=None,
             # Calls StreamResult API.
             case = subunit.ByteStreamToStreamResult(
                 stream, non_subunit_name='stdout')
-            if not retval and \
-               not _load_case(inserter, repo, case, subunit_out, pretty_out,
-                              color, stdout, abbreviate, suppress_attachments):
-                retval = 0
-            else:
+            result = _load_case(inserter, repo, case, subunit_out, pretty_out,
+                                color, stdout, abbreviate,
+                                suppress_attachments)
+            if result or retval:
                 retval = 1
+            else:
+                retval = 0
     else:
         case = testtools.ConcurrentStreamTestSuite(make_tests)
         retval = _load_case(inserter, repo, case, subunit_out, pretty_out,


### PR DESCRIPTION
This commit tries to fix the issue #137 "WARNING: missing Worker N!"
when using `stsetr run --failing` / `stestr load ..`.

We shouldn't use `testtools.ConcurrentStreamTestSuite` when we load
past subunit data. Because it doesn't match the load workers against
the run workers.

Fixes #137