### PR TITLE
Integrate with coverage

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -406,7 +406,6 @@ def run_command(config='.stestr.conf', repo_type='file',
         if omit:
             omit = "--omit=%s" % omit
 
-
     conf = config_file.TestrConf(config)
     if not analyze_isolation:
         cmd = conf.get_run_command(

--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,8 @@ commands =
 commands = {posargs}
 
 [testenv:cover]
-setenv =
-    VIRTUAL_ENV={envdir}
-    PYTHON=coverage run --source stestr
 commands =
-    coverage run stestr/cli.py run {posargs}
-    coverage combine
-    coverage html -d cover
+    stestr run --cover {posargs}
 
 [testenv:docs]
 commands = python setup.py build_sphinx


### PR DESCRIPTION
This commit adds `--coverage` option to integrate with `coverage`.

Fixes Issue #97