### PR TITLE
Cleanup unused parameters in _run_tests

### DIFF
--- a/stestr/bisect_tests.py
+++ b/stestr/bisect_tests.py
@@ -57,7 +57,7 @@ class IsolationAnalyzer(object):
                     repo_type=self.repo_type, repo_url=self.repo_url,
                     serial=self.serial, concurrency=self.concurrency,
                     test_path=self.test_path, top_dir=self.top_dir)
-                self.run_func(cmd, False, True, False, False,
+                self.run_func(cmd, False,
                               pretty_out=False,
                               repo_type=self.repo_type,
                               repo_url=self.repo_url)

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -397,7 +397,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                     randomize=random, test_path=test_path, top_dir=top_dir)
 
                 run_result = _run_tests(
-                    cmd, failing, analyze_isolation, isolated, until_failure,
+                    cmd, until_failure,
                     subunit_out=subunit_out, combine_id=combine_id,
                     repo_type=repo_type, repo_url=repo_url,
                     pretty_out=pretty_out, color=color, abbreviate=abbreviate,
@@ -406,8 +406,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                     result = run_result
             return result
         else:
-            return _run_tests(cmd, failing, analyze_isolation,
-                              isolated, until_failure,
+            return _run_tests(cmd, until_failure,
                               subunit_out=subunit_out,
                               combine_id=combine_id,
                               repo_type=repo_type,
@@ -432,8 +431,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                 whitelist_file=whitelist_file, black_regex=black_regex,
                 randomize=random, test_path=test_path,
                 top_dir=top_dir)
-            if not _run_tests(cmd, failing, analyze_isolation, isolated,
-                              until_failure):
+            if not _run_tests(cmd, until_failure):
                 # If the test was filtered, it won't have been run.
                 if test_id in repo.get_test_ids(repo.latest_id()):
                     spurious_failures.add(test_id)
@@ -458,7 +456,7 @@ def run_command(config='.stestr.conf', repo_type='file',
         return bisect_runner.bisect_tests(spurious_failures)
 
 
-def _run_tests(cmd, failing, analyze_isolation, isolated, until_failure,
+def _run_tests(cmd, until_failure,
                subunit_out=False, combine_id=None, repo_type='file',
                repo_url=None, pretty_out=True, color=False, stdout=sys.stdout,
                abbreviate=False, suppress_attachments=False):

--- a/stestr/tests/test_bisect_return_codes.py
+++ b/stestr/tests/test_bisect_return_codes.py
@@ -66,7 +66,7 @@ class TestBisectReturnCodes(base.TestCase):
         lines = six.text_type(out.rstrip()).splitlines()
         self.assertEqual(3, p_analyze.returncode,
                          'Analyze isolation returned an unexpected return code'
-                         'Stdout: %s\nStderr: %s' % (out, err))
+                         '\nStdout: %s\nStderr: %s' % (out, err))
         last_line = ('tests.test_serial_fails.TestFakeClass.test_B  '
                      'tests.test_serial_fails.TestFakeClass.test_A')
         self.assertEqual(last_line, lines[-1])


### PR DESCRIPTION
This commit just removes unused parameters - `failing`,
`analyze_isolation`, `isolated` from `_run_tests()` and its
usages. I'm not sure we have a plan to use the parameters in the
future, but we don't need them and a bit confusing at least so far.

And also, this commit adds a linefeed to the assert message to make
it better.