### PR TITLE
Introduce parallel-class option

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -356,7 +356,11 @@ method)::
 
     group_regex=([^\.]+\.)+
 
-Or, you can use the following option instead::
+However, because grouping tests at the class level is a common use case there is also a config option, ``parallel_class``, to do this. For example, you can use::
+
+    parallel_class=True
+    
+and it will group tests in the same class together.
 
     parallel_class=True
 

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -74,9 +74,10 @@ The ``group_regex`` option is used to specify is used to provide a scheduler
 hint for how tests should be divided between test runners. See the
 :ref:`group_regex` section for more information on how this works.
 You can also specify the ``parallel_class=True`` instead of
-``group_regex=([^\.]*\.)*``. This ``parallel_class`` option is to
-group tests together in the stestr scheduler by class. So, you don't
-need to memorize the complicated regex with it.
+group_regex to group tests in the stestr scheduler together by
+class. Since this is a common use case this enables that without
+needing to memorize the complicated regex for ``group_regex`` to do
+this.
 
 There is also an option to specify all the options in the config file via the
 CLI. This way you can run stestr directly without having to write a config file

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -73,6 +73,10 @@ A full example config file is::
 The ``group_regex`` option is used to specify is used to provide a scheduler
 hint for how tests should be divided between test runners. See the
 :ref:`group_regex` section for more information on how this works.
+You can also specify the ``parallel_class=True`` instead of
+``group_regex=([^\.]*\.)*``. This ``parallel_class`` option is to
+group tests together in the stestr scheduler by class. So, you don't
+need to memorize the complicated regex with it.
 
 There is also an option to specify all the options in the config file via the
 CLI. This way you can run stestr directly without having to write a config file
@@ -351,6 +355,18 @@ tests in the same class together (the last '.' splits the class and test
 method)::
 
     group_regex=([^\.]+\.)+
+
+Or, you can use the following option instead::
+
+    parallel_class=True
+
+.. note::
+   This ``parallel_class`` option takes priority over the
+   ``group_regex`` option. And if both on the CLI and in the config
+   are set, we use the option on the CLI not in a config file. For
+   example, ``--group-regex`` on the CLI and ``parallel-class`` in a
+   config file are set, ``--group-regex`` is higer priority than
+   ``parallel-class`` in this case.
 
 Test Scheduling
 ---------------

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -356,13 +356,13 @@ method)::
 
     group_regex=([^\.]+\.)+
 
-However, because grouping tests at the class level is a common use case there is also a config option, ``parallel_class``, to do this. For example, you can use::
+However, because grouping tests at the class level is a common use
+case there is also a config option, ``parallel_class``, to do
+this. For example, you can use::
 
     parallel_class=True
-    
+
 and it will group tests in the same class together.
-
-    parallel_class=True
 
 .. note::
    This ``parallel_class`` option takes priority over the

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -34,6 +34,9 @@ class StestrCLI(app.App):
 
     def prepare_to_run_command(self, cmd):
         self.LOG.debug('prepare_to_run_command %s', cmd.__class__.__name__)
+        group_regex = '([^\.]*\.)*' \
+            if cmd.app_args.parallel_class else cmd.app_args.group_regex
+        cmd.app_args.group_regex = group_regex
 
     def clean_up(self, cmd, result, err):
         self.LOG.debug('clean_up %s', cmd.__class__.__name__)
@@ -92,6 +95,12 @@ class StestrCLI(app.App):
                                  " together in the stestr scheduler. If "
                                  "both this and the corresponding config file "
                                  "option are set this value will be used.")
+        parser.add_argument('--parallel-class', '-p',
+                            action='store_true',
+                            default=False,
+                            help="Set the flag to group tests by class. NOTE: "
+                                 "This flag takes priority over the "
+                                 "`--group-regex` option even if it's set.")
 
         return parser
 

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -29,12 +29,16 @@ class TestTestrConf(base.TestCase):
     @mock.patch.object(config_file, 'sys')
     def _check_get_run_command(self, mock_sys, mock_TestProcessorFixture,
                                mock_get_repo_open, platform='win32',
-                               expected_python='python'):
+                               group_regex='.*', parallel_class=False,
+                               expected_python='python',
+                               expected_group_callback=mock.ANY):
         mock_sys.platform = platform
 
-        fixture = self._testr_conf.get_run_command(test_path='fake_test_path',
-                                                   top_dir='fake_top_dir',
-                                                   group_regex='.*')
+        fixture = \
+            self._testr_conf.get_run_command(test_path='fake_test_path',
+                                             top_dir='fake_top_dir',
+                                             group_regex=group_regex,
+                                             parallel_class=parallel_class)
 
         self.assertEqual(mock_TestProcessorFixture.return_value, fixture)
         mock_get_repo_open.assert_called_once_with('file',
@@ -46,7 +50,8 @@ class TestTestrConf(base.TestCase):
         mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
             mock_get_repo_open.return_value, black_regex=None,
-            blacklist_file=None, concurrency=0, group_callback=mock.ANY,
+            blacklist_file=None, concurrency=0,
+            group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,
             whitelist_file=None, worker_path=None)
 
@@ -56,3 +61,11 @@ class TestTestrConf(base.TestCase):
 
     def test_get_run_command_win32(self):
         self._check_get_run_command()
+
+    def test_get_run_command_parallel_class(self):
+        self._check_get_run_command(parallel_class=True)
+
+    def test_get_run_command_nogroup_regex_noparallel_class(self):
+        self._testr_conf.parser.has_option.return_value = False
+        self._check_get_run_command(group_regex='',
+                                    expected_group_callback=None)

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -192,6 +192,13 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run --until-failure --subunit', 1,
                            subunit=True)
 
+    def test_with_parallel_class(self):
+        # NOTE(masayukig): Ideally, it's better to figure out the
+        # difference between with --parallel-class and without
+        # --parallel-class. However, it's difficult to make such a
+        # test from a command line based test.
+        self.assertRunExit('stestr --parallel-class run passing', 0)
+
     def test_list(self):
         self.assertRunExit('stestr list', 0)
 


### PR DESCRIPTION
This commit introduces the parallel-class option to the CLI and config
file. The option take priority over group_regex. And if both on the
CLI and in the config are set, we use the option on the CLI not in a
config file.

For example, `--group-regex` on the CLI and `parallel-class` in a
config file are set, `--group-regex` is higer priority than
`parallel-class` in this case.

Fixes #198