### PR TITLE
Fix discovery import error formatting on py3

### DIFF
--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -211,9 +211,15 @@ class TestProcessorFixture(fixtures.Fixture):
                     results.CatFiles(new_out))
             out = new_out.getvalue()
             if out:
-                sys.stdout.write(six.text_type(out))
+                if six.PY3:
+                    sys.stdout.write(out.decode('utf8'))
+                else:
+                    sys.stdout.write(out)
             if err:
-                sys.stderr.write(six.text_type(err))
+                if six.PY3:
+                    sys.stdout.write(out.decode('utf8'))
+                else:
+                    sys.stderr.write(err)
             sys.stdout.write("\n" + "=" * 80 + "\n"
                              "The above traceback was encountered during "
                              "test discovery which imports all the found test"


### PR DESCRIPTION
This commit fixes the formatting when we print the errors encountered
during discovery. Because python3 returns a bytes object from subprocess
just casting it as a str() won't make the ouptut respect the the
newlines and tabs. To fix the issue this commit splits out the py3 case
and properly decodes the bytes as utf8 data and pass that to
sys.stdout.write().