### PR TITLE
Change title of project in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Slim/Super Test Repository
-==========================
+stestr
+======
 
 .. image:: https://img.shields.io/travis/mtreinish/stestr/master.svg?style=flat-square
     :target: https://travis-ci.org/mtreinish/stestr


### PR DESCRIPTION
No one calls stestr Slim Test Repository or Super Test Repository, so
lets stop referring to it as that. stestr should just be stestr, for
better or worse, and not stand for anything. This commit just updates
the readme to reflect this.