### PR TITLE
Improved test coverage for stestr run --subunit 0 exit status

### DIFF
--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -172,11 +172,19 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit(cmd, 0)
 
     def test_serial_subunit_passing(self):
-        self.assertRunExit('stestr run --subunit passing', 0,
-                           subunit=True)
+        self.assertRunExit('stestr run --subunit --serial passing',
+                           0, subunit=True)
+
+    def test_serial_subunit_failing(self):
+        self.assertRunExit('stestr run --subunit --serial failing',
+                           0, subunit=True)
 
     def test_parallel_subunit_passing(self):
         self.assertRunExit('stestr run --subunit passing', 0,
+                           subunit=True)
+
+    def test_parallel_subunit_failing(self):
+        self.assertRunExit('stestr run --subunit failing', 0,
                            subunit=True)
 
     def test_slowest_passing(self):

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -176,6 +176,7 @@ class TestReturnCodes(base.TestCase):
     def test_serial_subunit_passing(self):
         self.assertRunExit('stestr --user-config stestr.yaml run --subunit '
                            '--serial passing', 0, subunit=True)
+
     def test_serial_subunit_failing(self):
         self.assertRunExit('stestr --user-config stestr.yaml run --subunit '
                            '--serial failing', 0, subunit=True)


### PR DESCRIPTION
stestr run --subunit always returns 0 exit status irrespective
of the tests passes or fail. It improves the test coverage for
the same.

It also fixes the test command for test_serial_subunit_passing.