### PR TITLE
Put in quotes the top_dir and test_path

### DIFF
--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -104,8 +104,8 @@ class TestrConf(object):
             top_dir = './'
 
         python = 'python' if sys.platform == 'win32' else '${PYTHON:-python}'
-        command = "%s -m subunit.run discover -t" \
-                  " %s %s $LISTOPT $IDOPTION" % (python, top_dir, test_path)
+        command = '%s -m subunit.run discover -t "%s" "%s" ' \
+                  '$LISTOPT $IDOPTION' % (python, top_dir, test_path)
         listopt = "--list"
         idoption = "--load-list $IDFILE"
         # If the command contains $IDOPTION read that command from config

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -43,8 +43,9 @@ class TestTestrConf(base.TestCase):
         self.assertEqual(mock_TestProcessorFixture.return_value, fixture)
         mock_get_repo_open.assert_called_once_with('file',
                                                    None)
-        command = "%s -m subunit.run discover -t %s %s $LISTOPT $IDOPTION" % (
-            expected_python, 'fake_top_dir', 'fake_test_path')
+        command = '%s -m subunit.run discover -t "%s" "%s" ' \
+                  '$LISTOPT $IDOPTION' % (expected_python, 'fake_top_dir',
+                                          'fake_test_path')
         # Ensure TestProcessorFixture is created with defaults except for where
         # we specfied and with the correct python.
         mock_TestProcessorFixture.assert_called_once_with(


### PR DESCRIPTION
In case of top_dir and test_path contains a space, stestr fails.
Putting these variables in quotes fixes the problem.

Fix #211