### PR TITLE
Update docs for exit codes with --subunit flags

### DIFF
--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -24,20 +24,18 @@ from stestr import user_config
 
 
 class Failing(command.Command):
-    def get_description(self):
-        help_str = """Show the current failures known by the repository.
+    """Show the current failures known by the repository.
 
-        Without --subunit, the process exit code will be non-zero if the
-        previous test run was not successful and test failures are shown. But,
-        with --subunit, the process exit code is non-zero only if the subunit
-        stream could not be generated successfully from any failures. The test
-        results and run status are included in the subunit stream emitted for
-        the failed tests, so the stream should be used for interpretting the
-        failing tests. If no subunit stream is emitted with --subunit and a
-        zero exit code then there were no failures in the most recent run in
-        the repository.
-        """
-        return help_str
+    Without --subunit, the process exit code will be non-zero if the
+    previous test run was not successful and test failures are shown. But,
+    with --subunit, the process exit code is non-zero only if the subunit
+    stream could not be generated successfully from any failures. The test
+    results and run status are included in the subunit stream emitted for
+    the failed tests, so the stream should be used for interpretting the
+    failing tests. If no subunit stream is emitted with --subunit and a
+    zero exit code then there were no failures in the most recent run in
+    the repository.
+    """
 
     def get_parser(self, prog_name):
         parser = super(Failing, self).get_parser(prog_name)

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -25,7 +25,19 @@ from stestr import user_config
 
 class Failing(command.Command):
     def get_description(self):
-        return "Show the current failures known by the repository"
+        help_str = """Show the current failures known by the repository.
+
+        Without --subunit, the process exit code will be non-zero if the
+        previous test run was not successful and test failures are shown. But,
+        with --subunit, the process exit code is non-zero only if the subunit
+        stream could not be generated successfully from any failures. The test
+        results and run status are included in the subunit stream emitted for
+        the failed tests, so the stream should be used for interpretting the
+        failing tests. If no subunit stream is emitted with --subunit and a
+        zero exit code then there were no failures in the most recent run in
+        the repository.
+        """
+        return help_str
 
     def get_parser(self, prog_name):
         parser = super(Failing, self).get_parser(prog_name)

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -33,7 +33,10 @@ class Last(command.Command):
 
         Without --subunit, the process exit code will be non-zero if the test
         run was not successful. With --subunit, the process exit code is
-        non-zero if the subunit stream could not be generated successfully.
+        non-zero only if the subunit stream could not be generated
+        successfully. The test results and run status are included in the
+        subunit stream, so the stream should be used to determining the result
+        of the run instead of the exit code when using the --subunit flag.
         """
         return help_str
 

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -25,20 +25,18 @@ from stestr import user_config
 
 
 class Last(command.Command):
-    def get_description(self):
-        help_str = """Show the last run loaded into a repository.
+    """Show the last run loaded into a repository.
 
-        Failing tests are shown on the console and a summary of the run is
-        printed at the end.
+    Failing tests are shown on the console and a summary of the run is
+    printed at the end.
 
-        Without --subunit, the process exit code will be non-zero if the test
-        run was not successful. With --subunit, the process exit code is
-        non-zero only if the subunit stream could not be generated
-        successfully. The test results and run status are included in the
-        subunit stream, so the stream should be used to determining the result
-        of the run instead of the exit code when using the --subunit flag.
-        """
-        return help_str
+    Without --subunit, the process exit code will be non-zero if the test
+    run was not successful. With --subunit, the process exit code is
+    non-zero only if the subunit stream could not be generated
+    successfully. The test results and run status are included in the
+    subunit stream, so the stream should be used to determining the result
+    of the run instead of the exit code when using the --subunit flag.
+    """
 
     def get_parser(self, prog_name):
         parser = super(Last, self).get_parser(prog_name)

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -32,6 +32,19 @@ from stestr import utils
 
 
 class Load(command.Command):
+    """Load a subunit stream into a repository.
+
+    Failing tests are shown on the console and a summary of the stream
+    is printed at the end.
+
+    Without --subunit, the process exit code will be non-zero if the test
+    run was not successful. With --subunit, the process exit code is
+    non-zero if the subunit stream could not be generated successfully.
+    The test results and run status are included in the subunit stream, so
+    the stream should be used to determining the result of the run instead
+    of the exit code when using the --subunit flag.
+    """
+
     def get_parser(self, prog_name):
         parser = super(Load, self).get_parser(prog_name)
         parser.add_argument("files", nargs="*", default=False,
@@ -69,21 +82,6 @@ class Load(command.Command):
                             'attachment contents on a successful test '
                             'execution')
         return parser
-
-    def get_description(self):
-        help_str = """Load a subunit stream into a repository.
-
-        Failing tests are shown on the console and a summary of the stream
-        is printed at the end.
-
-        Without --subunit, the process exit code will be non-zero if the test
-        run was not successful. With --subunit, the process exit code is
-        non-zero if the subunit stream could not be generated successfully.
-        The test results and run status are included in the subunit stream, so
-        the stream should be used to determining the result of the run instead
-        of the exit code when using the --subunit flag.
-        """
-        return help_str
 
     def take_action(self, parsed_args):
         user_conf = user_config.get_user_config(self.app_args.user_config)

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -73,9 +73,16 @@ class Load(command.Command):
     def get_description(self):
         help_str = """Load a subunit stream into a repository.
 
-            Failing tests are shown on the console and a summary of the stream
-            is printed at the end.
-            """
+        Failing tests are shown on the console and a summary of the stream
+        is printed at the end.
+
+        Without --subunit, the process exit code will be non-zero if the test
+        run was not successful. With --subunit, the process exit code is
+        non-zero if the subunit stream could not be generated successfully.
+        The test results and run status are included in the subunit stream, so
+        the stream should be used to determining the result of the run instead
+        of the exit code when using the --subunit flag.
+        """
         return help_str
 
     def take_action(self, parsed_args):

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -35,6 +35,16 @@ from stestr import user_config
 
 
 class Run(command.Command):
+    """Run the tests for a project and store them into the repository.
+
+    Without --subunit, the process exit code will be non-zero if the test
+    run was not successful. However, with --subunit, the process exit code
+    is non-zero only if the subunit stream could not be generated
+    successfully. The test results and run status are included in the
+    subunit stream, so the stream should be used to determining the result
+    of the run instead of the exit code when using the --subunit flag.
+    """
+
     def get_parser(self, prog_name):
         parser = super(Run, self).get_parser(prog_name)
         parser.add_argument("filters", nargs="*", default=None,
@@ -132,19 +142,6 @@ class Run(command.Command):
                             'attachment contents on a successful test '
                             'execution')
         return parser
-
-    def get_description(self):
-        help_str = """Run the tests for a project and store them into the
-        repository.
-
-        Without --subunit, the process exit code will be non-zero if the test
-        run was not successful. However, with --subunit, the process exit code
-        is non-zero only if the subunit stream could not be generated
-        successfully. The test results and run status are included in the
-        subunit stream, so the stream should be used to determining the result
-        of the run instead of the exit code when using the --subunit flag.
-        """
-        return help_str
 
     def take_action(self, parsed_args):
         user_conf = user_config.get_user_config(self.app_args.user_config)

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -134,8 +134,16 @@ class Run(command.Command):
         return parser
 
     def get_description(self):
-        help_str = (
-            "Run the tests for a project and store them into the repository.")
+        help_str = """Run the tests for a project and store them into the
+        repository.
+
+        Without --subunit, the process exit code will be non-zero if the test
+        run was not successful. However, with --subunit, the process exit code
+        is non-zero only if the subunit stream could not be generated
+        successfully. The test results and run status are included in the
+        subunit stream, so the stream should be used to determining the result
+        of the run instead of the exit code when using the --subunit flag.
+        """
         return help_str
 
     def take_action(self, parsed_args):


### PR DESCRIPTION
The --subunit flag changes the exit code behavior in a slightly
counter intuitive manner. Basically instead of exiting non-zero when
there are failure results it only returns non-zero if subunit generation
fails. This is expected behavior, but was not clearly documented which
can cause confusion. It was only mentioned in the description for the
'last' command, and not all the commands where --subunit was available.
This commit attempts to address that by adding clear documentation to
the description string for each command. This means it will be printed
in the summary for '--help' on each command as well as ending up in the
project man page for each command.

Fixes #210