### PR TITLE
Gracefully handle the case when sys.executable is None

### DIFF
--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import os
 import re
 import sys
 
@@ -103,8 +104,22 @@ class TestrConf(object):
         elif not top_dir:
             top_dir = './'
 
-        python = sys.executable if sys.platform == 'win32' else \
-            '${PYTHON:-%s}' % (sys.executable)
+        stestr_python = sys.executable
+        # let's try to be explicit, even if it means a longer set of ifs
+        if sys.platform == 'win32':
+            # it may happen, albeit rarely
+            if not stestr_python:
+                raise RuntimeError("The Python interpreter was not found")
+            python = stestr_python
+        else:
+            if os.environ.get('PYTHON'):
+                python = '${PYTHON}'
+            elif stestr_python:
+                python = stestr_python
+            else:
+                raise RuntimeError("The Python interpreter was not found and "
+                                   "PYTHON is not set")
+
         command = '%s -m subunit.run discover -t "%s" "%s" ' \
                   '$LISTOPT $IDOPTION' % (python, top_dir, test_path)
         listopt = "--list"

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -30,16 +30,21 @@ class TestTestrConf(base.TestCase):
     def _check_get_run_command(self, mock_sys, mock_TestProcessorFixture,
                                mock_get_repo_open, platform='win32',
                                group_regex='.*', parallel_class=False,
-                               expected_python='python',
-                               expected_group_callback=mock.ANY):
+                               sys_executable='/usr/bin/python',
+                               expected_python='/usr/bin/python',
+                               expected_group_callback=mock.ANY,
+                               environment=None):
         mock_sys.platform = platform
-        mock_sys.executable = 'python'
+        mock_sys.executable = sys_executable
+        if environment is None:
+            environment = {'PYTHON': ''}
 
-        fixture = \
-            self._testr_conf.get_run_command(test_path='fake_test_path',
-                                             top_dir='fake_top_dir',
-                                             group_regex=group_regex,
-                                             parallel_class=parallel_class)
+        with mock.patch.dict('os.environ', environment):
+            fixture = \
+                self._testr_conf.get_run_command(test_path='fake_test_path',
+                                                 top_dir='fake_top_dir',
+                                                 group_regex=group_regex,
+                                                 parallel_class=parallel_class)
 
         self.assertEqual(mock_TestProcessorFixture.return_value, fixture)
         mock_get_repo_open.assert_called_once_with('file',
@@ -57,9 +62,40 @@ class TestTestrConf(base.TestCase):
             test_filters=None, randomize=False, serial=False,
             whitelist_file=None, worker_path=None)
 
+    @mock.patch.object(config_file, 'sys')
+    def _check_get_run_command_exception(self, mock_sys, platform='win32',
+                                         sys_executable='/usr/bin/python',
+                                         environment=None):
+        mock_sys.platform = platform
+        mock_sys.executable = sys_executable
+        if environment is None:
+            environment = {'PYTHON': ''}
+
+        with mock.patch.dict('os.environ', environment):
+            self.assertRaises(RuntimeError, self._testr_conf.get_run_command,
+                              test_path='fake_test_path',
+                              top_dir='fake_top_dir')
+
     def test_get_run_command_linux(self):
-        self._check_get_run_command(platform='linux2',
-                                    expected_python='${PYTHON:-python}')
+        self._check_get_run_command(
+            platform='linux2',
+            expected_python='/usr/bin/python')
+
+    def test_get_run_command_emptysysexecutable_noenv(self):
+        self._check_get_run_command_exception(
+            platform='linux2',
+            sys_executable=None)
+
+    def test_get_run_command_emptysysexecutable_win32(self):
+        self._check_get_run_command_exception(
+            platform='win32', sys_executable=None,
+            environment={'PYTHON': 'python3'})
+
+    def test_get_run_command_emptysysexecutable_withenv(self):
+        self._check_get_run_command(
+            platform='linux2', sys_executable=None,
+            expected_python='${PYTHON}',
+            environment={'PYTHON': '/usr/bin/python3'})
 
     def test_get_run_command_win32(self):
         self._check_get_run_command()


### PR DESCRIPTION
It may happen, even if it is extremely unlikely.
Just return 'python': it may work, or just fail later - but it would
have failed anyway.

This is a follow-up of the main fix for #215.