### PR TITLE
Turn on debug mode by default

### DIFF
--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -30,6 +30,7 @@ class StestrCLI(app.App):
             )
 
     def initialize_app(self, argv):
+        self.options.debug = True
         self.LOG.debug('initialize_app')
 
     def prepare_to_run_command(self, cmd):


### PR DESCRIPTION
By default cliff suppresses stack traces on unhandled exceptions in order
to keep the output cleaner for users. But in practice this has caused more
confusion for stestr users since often the error messages aren't really
descriptive enough to indicate what's going wrong (or that it's even a
bug in stestr). This is often because exception messages are written
assuming the context of the stack trace for debugging, not to be user
facing messages. Cliff offers the --debug flag to enable printing the
full stack traces. This commit turns that flag on by default when stestr
initializes the cliff App object to ensure that it always prints the
full stack trace on an unhandled exception.

Fixes #220