### PR TITLE
Use default user config in unit tests

### DIFF
--- a/stestr/tests/test_bisect_return_codes.py
+++ b/stestr/tests/test_bisect_return_codes.py
@@ -33,10 +33,12 @@ class TestBisectReturnCodes(base.TestCase):
         self.setup_cfg_file = os.path.join(self.directory, 'setup.cfg')
         self.init_file = os.path.join(self.test_dir, '__init__.py')
         self.setup_py = os.path.join(self.directory, 'setup.py')
+        self.user_config = os.path.join(self.directory, 'stestr.yaml')
         shutil.copy('stestr/tests/files/testr-conf', self.testr_conf_file)
         shutil.copy('setup.py', self.setup_py)
         shutil.copy('stestr/tests/files/setup.cfg', self.setup_cfg_file)
         shutil.copy('stestr/tests/files/__init__.py', self.init_file)
+        shutil.copy('stestr/tests/files/stestr.yaml', self.user_config)
 
         # Move around the test code
         self.serial_fail_file = os.path.join(self.test_dir,
@@ -58,8 +60,8 @@ class TestBisectReturnCodes(base.TestCase):
                          'stestr run returned an unexpected return code'
                          'Stdout: %s\nStderr: %s' % (out, err))
         p_analyze = subprocess.Popen(
-            "stestr run --analyze-isolation", shell=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            "stestr --user-config stestr.yaml run --analyze-isolation",
+            shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p_analyze.communicate()
         out = out.decode('utf-8')
         # For debugging potential failures

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -46,12 +46,14 @@ class TestReturnCodes(base.TestCase):
         self.failing_file = os.path.join(self.test_dir, 'test_failing.py')
         self.init_file = os.path.join(self.test_dir, '__init__.py')
         self.setup_py = os.path.join(self.directory, 'setup.py')
+        self.user_config = os.path.join(self.directory, 'stestr.yaml')
         shutil.copy('stestr/tests/files/testr-conf', self.testr_conf_file)
         shutil.copy('stestr/tests/files/passing-tests', self.passing_file)
         shutil.copy('stestr/tests/files/failing-tests', self.failing_file)
         shutil.copy('setup.py', self.setup_py)
         shutil.copy('stestr/tests/files/setup.cfg', self.setup_cfg_file)
         shutil.copy('stestr/tests/files/__init__.py', self.init_file)
+        shutil.copy('stestr/tests/files/stestr.yaml', self.user_config)
 
         self.stdout = StringIO()
         self.stderr = StringIO()
@@ -172,12 +174,12 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit(cmd, 0)
 
     def test_serial_subunit_passing(self):
-        self.assertRunExit('stestr run --subunit passing', 0,
-                           subunit=True)
+        self.assertRunExit('stestr --user-config stestr.yaml run --subunit '
+                           '--serial passing', 0, subunit=True)
 
     def test_parallel_subunit_passing(self):
-        self.assertRunExit('stestr run --subunit passing', 0,
-                           subunit=True)
+        self.assertRunExit('stestr --user-config stestr.yaml run --subunit '
+                           'passing', 0, subunit=True)
 
     def test_slowest_passing(self):
         self.assertRunExit('stestr run --slowest passing', 0)
@@ -189,8 +191,8 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run --until-failure', 1)
 
     def test_until_failure_with_subunit_fails(self):
-        self.assertRunExit('stestr run --until-failure --subunit', 1,
-                           subunit=True)
+        self.assertRunExit('stestr --user-config stestr.yaml run '
+                           '--until-failure --subunit', 1, subunit=True)
 
     def test_with_parallel_class(self):
         # NOTE(masayukig): Ideally, it's better to figure out the
@@ -240,13 +242,14 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr load', 0, stdin=stream)
 
     def test_load_from_stdin_quiet(self):
-        out, err = self.assertRunExit('stestr -q run passing', 0)
+        out, err = self.assertRunExit('stestr --user-config stestr.yaml -q '
+                                      'run passing', 0)
         self.assertEqual(out.decode('utf-8'), '')
         # FIXME(masayukig): We get some warnings when we run a coverage job.
         # So, just ignore 'err' here.
-        stream = self._get_cmd_stdout(
-            'stestr last --subunit')[0]
-        out, err = self.assertRunExit('stestr -q load', 0, stdin=stream)
+        stream = self._get_cmd_stdout('stestr last --subunit')[0]
+        out, err = self.assertRunExit('stestr --user-config stestr.yaml -q '
+                                      'load', 0, stdin=stream)
         self.assertEqual(out.decode('utf-8'), '')
         self.assertEqual(err.decode('utf-8'), '')
 


### PR DESCRIPTION
This commit makes some unit tests use an empty user config file as a
default setting. Otherwise, it can be failed with user config settings
depending on a test user's user config.

And this commit also fixes `test_serial_subunit_passing` to have
`--serial` option for its objective.