### PR TITLE
Add support to repositories for storing run metadata

### DIFF
--- a/stestr/repository/abstract.py
+++ b/stestr/repository/abstract.py
@@ -67,7 +67,7 @@ class AbstractRepository(object):
         """
         raise NotImplementedError(self.get_failing)
 
-    def get_inserter(self, partial=False, run_id=None):
+    def get_inserter(self, partial=False, run_id=None, metadata=None):
         """Get an inserter that will insert a test run into the repository.
 
         Repository implementations should implement _get_inserter.
@@ -83,9 +83,9 @@ class AbstractRepository(object):
             that testtools 0.9.2 and above offer. The startTestRun and
             stopTestRun methods in particular must be called.
         """
-        return self._get_inserter(partial, run_id)
+        return self._get_inserter(partial, run_id, metadata)
 
-    def _get_inserter(self, partial=False, run_id=None):
+    def _get_inserter(self, partial=False, run_id=None, metadata=None):
         """Get an inserter for get_inserter.
 
         The result is decorated with an AutoTimingTestResultDecorator.
@@ -156,6 +156,14 @@ class AbstractRepository(object):
             result.stopTestRun()
         return ids
 
+    def find_metadata(self, metadata):
+        """Return the list of run_ids for a given metadata string.
+
+        :param: metadata: the metadata string to search for.
+        :return: a list of any test_ids that have that metadata value.
+        """
+        raise NotImplementedError(self.find_metadata)
+
 
 class AbstractTestRun(object):
     """A test run that has been stored in a repository.
@@ -185,6 +193,13 @@ class AbstractTestRun(object):
             decorator to permit either API to be used).
         """
         raise NotImplementedError(self.get_test)
+
+    def get_metadata(self):
+        """Get the metadata value for the test run.
+
+        :return: A string of the metadata or None if it doesn't exist.
+        """
+        raise NotImplementedError(self.get_metadata)
 
 
 class RepositoryNotFound(Exception):

--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -20,7 +20,6 @@ import sys
 import tempfile
 
 from future.moves.dbm import dumb as my_dbm
-import six
 from subunit import TestProtocolClient
 import subunit.v2
 import testtools
@@ -285,8 +284,8 @@ class _SafeInserter(object):
         if self._metadata:
             db = my_dbm.open(self._repository._path('meta.dbm'), 'c')
             try:
-                dbm_run_id = six.text_type(run_id)
-                db[dbm_run_id] = self._metadata
+                dbm_run_id = str(run_id)
+                db[dbm_run_id] = str(self._metadata)
             finally:
                 db.close()
 

--- a/stestr/repository/memory.py
+++ b/stestr/repository/memory.py
@@ -72,7 +72,7 @@ class Repository(repository.AbstractRepository):
         return result
 
     def _get_inserter(self, partial, run_id=None, metadata=None):
-         return _Inserter(self, partial, run_id, metadata)
+        return _Inserter(self, partial, run_id, metadata)
 
     def _get_test_times(self, test_ids):
         result = {}

--- a/stestr/repository/memory.py
+++ b/stestr/repository/memory.py
@@ -71,7 +71,7 @@ class Repository(repository.AbstractRepository):
             raise KeyError("No tests in repository")
         return result
 
-    def _get_inserter(self, partial, run_id=None):
+    def _get_inserter(self, partial, run_id=None, metadata=None):
         return _Inserter(self, partial, run_id)
 
     def _get_test_times(self, test_ids):
@@ -127,13 +127,14 @@ class _Failures(repository.AbstractTestRun):
 class _Inserter(repository.AbstractTestRun):
     """Insert test results into a memory repository."""
 
-    def __init__(self, repository, partial, run_id=None):
+    def __init__(self, repository, partial, run_id=None, metadata=None):
         self._repository = repository
         self._partial = partial
         self._tests = []
         # Subunit V2 stream for get_subunit_stream
         self._subunit = None
         self._run_id = run_id
+        self._metadata = metadata
 
     def startTestRun(self):
         self._subunit = BytesIO()

--- a/stestr/repository/memory.py
+++ b/stestr/repository/memory.py
@@ -72,7 +72,7 @@ class Repository(repository.AbstractRepository):
         return result
 
     def _get_inserter(self, partial, run_id=None, metadata=None):
-        return _Inserter(self, partial, run_id)
+         return _Inserter(self, partial, run_id, metadata)
 
     def _get_test_times(self, test_ids):
         result = {}

--- a/stestr/tests/repository/test_file.py
+++ b/stestr/tests/repository/test_file.py
@@ -117,3 +117,24 @@ class TestFileRepository(base.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(repo.base, '0')))
         os.chmod(os.path.join(repo.base, '0'), 0000)
         self.assertRaises(IOError, repo.get_test_run, '0')
+
+    def test_get_metadata(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter(metadata='fun')
+        result.startTestRun()
+        result.stopTestRun()
+        run = repo.get_test_run(result.get_id())
+        self.assertEqual(b'fun', run.get_metadata())
+
+    def test_find_metadata(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter(metadata='fun')
+        result.startTestRun()
+        result.stopTestRun()
+        result_bad = repo.get_inserter(metadata='not_fun')
+        result_bad.startTestRun()
+        result_bad.stopTestRun()
+        run_ids = repo.find_metadata(b'fun')
+        run_ids_int = [int(x) for x in run_ids]
+        self.assertIn(result.get_id(), run_ids_int)
+        self.assertNotIn(result_bad.get_id(), run_ids_int)

--- a/stestr/tests/repository/test_sql.py
+++ b/stestr/tests/repository/test_sql.py
@@ -18,6 +18,7 @@ import tempfile
 import uuid
 
 import fixtures
+import testtools
 
 from stestr.repository import sql
 from stestr.tests import base
@@ -81,6 +82,7 @@ class TestSqlRepository(base.TestCase):
         self.assertTrue(stream.readable())
         self.assertEqual([], stream.readlines())
 
+    @testtools.skipIf(os.name == 'nt', 'tempfile fails on appveyor')
     def test_get_metadata(self):
         repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
         result = repo.get_inserter(metadata='fun')
@@ -89,6 +91,7 @@ class TestSqlRepository(base.TestCase):
         run = repo.get_test_run(result.get_id())
         self.assertEqual('fun', run.get_metadata())
 
+    @testtools.skipIf(os.name == 'nt', 'tempfile fails on appveyor')
     def test_find_metadata(self):
         repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
         result = repo.get_inserter(metadata='fun')

--- a/stestr/tests/repository/test_sql.py
+++ b/stestr/tests/repository/test_sql.py
@@ -80,3 +80,23 @@ class TestSqlRepository(base.TestCase):
         self.assertIsNotNone(stream)
         self.assertTrue(stream.readable())
         self.assertEqual([], stream.readlines())
+
+    def test_get_metadata(self):
+        repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
+        result = repo.get_inserter(metadata='fun')
+        result.startTestRun()
+        result.stopTestRun()
+        run = repo.get_test_run(result.get_id())
+        self.assertEqual('fun', run.get_metadata())
+
+    def test_find_metadata(self):
+        repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
+        result = repo.get_inserter(metadata='fun')
+        result.startTestRun()
+        result.stopTestRun()
+        result_bad = repo.get_inserter(metadata='not_fun')
+        result_bad.startTestRun()
+        result_bad.stopTestRun()
+        run_ids = repo.find_metadata('fun')
+        self.assertIn(result.get_id(), run_ids)
+        self.assertNotIn(result_bad.get_id(), run_ids)


### PR DESCRIPTION
This commit adds repository APIs around storing and accessing run
metadata strings. The concept being that you can store a metadata string
to identify a run by some other identifier then the run id. The example
use case in mind for this feature is using it to store a VCS commit hash
(like a git sha1) or identifier. The APIs in this commit allow storing
metadata at run creation time, accessing the metadata for a run, and
finding run_ids by a metadata value. This is implemented for both the
file and sql repository types. The memory repository type does not have
this implemented, as it is more limited.

Related to: #224