### PR TITLE
Move from get_description() to class docstrings part-2

### DIFF
--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -20,12 +20,10 @@ from stestr.repository import util
 
 
 class Init(command.Command):
+    """Create a new repository."""
+
     def take_action(self, parsed_args):
         init(self.app_args.repo_type, self.app_args.repo_url)
-
-    def get_description(self):
-        help_str = "Create a new repository."
-        return help_str
 
 
 def init(repo_type='file', repo_url=None, stdout=sys.stdout):

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -22,12 +22,11 @@ from stestr import output
 
 
 class List(command.Command):
+    """List the tests for a project.
 
-    def get_description(self):
-        help_str = ("List the tests for a project. You can use a filter just "
-                    "like with the run command to see exactly what tests "
-                    "match")
-        return help_str
+    You can use a filter just like with the run command to see exactly what
+    tests match.
+    """
 
     def get_parser(self, prog_name):
         parser = super(List, self).get_parser(prog_name)

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -23,13 +23,10 @@ from stestr.repository import util
 
 
 class Slowest(command.Command):
-    def get_description(self):
-        help_str = """Show the slowest tests from the last test run.
+    """Show the slowest tests from the last test run.
 
-        This command shows a table, with the longest running
-        tests at the top.
-        """
-        return help_str
+    This command shows a table, with the longest running tests at the top.
+    """
 
     def get_parser(self, prog_name):
         parser = super(Slowest, self).get_parser(prog_name)


### PR DESCRIPTION
This commit moves help descriptions in the rest of the commands. We
found that in #214 conversation and fixed some already. But we decided
to make a separate PR for this fixing there.

Related Issue: #214