### PR TITLE
Add links to GitHub repo and project-urls to metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,8 @@ stestr
     :target: https://pypi.python.org/pypi/stestr
     :alt: Latest Version
 
-You can see the full rendered docs at: http://stestr.readthedocs.io/en/latest/
+* You can see the full rendered docs at: http://stestr.readthedocs.io/en/latest/
+* The code of the project is on Github: https://github.com/mtreinish/stestr
 
 Overview
 --------

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,10 @@ classifier =
     Programming Language :: Python :: 3.7
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
+project-urls =
+    Documentation = https://stestr.readthedocs.io
+    Source = https://github.com/mtreinish/stestr
+    Tracker = https://github.com/mtreinish/stestr/issues
 
 [files]
 packages =


### PR DESCRIPTION
This commit adds the GitHub repo and readthedocs links to README.rst and
setup.cfg to try to make it easier to find it.

Issues #218