### PR TITLE
Inline CONTRIBUTING.rst in README.rst and add to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,3 +118,18 @@ from the root of the stestr repository::
 
 which will generate the troff file in doc/build/man/stestr.1 which is ready to
 be packaged and or put in your system's man pages.
+
+Contributing
+------------
+
+To browse the latest code, see: https://github.com/mtreinish/stestr
+To clone the latest code, use: ``git clone https://github.com/mtreinish/stestr.git``
+
+Guidelines for contribution are documented at: http://stestr.readthedocs.io/en/latest/developer_guidelines.html
+
+Use `github pull requests`_ to submit patches. Before you submit a pull request
+ensure that all the automated testing will pass by running ``tox`` locally.
+This will run the test suite and also the automated style rule checks just as
+they will in CI. If CI fails on your change it will not be able to merge.
+
+.. _github pull requests: https://help.github.com/articles/about-pull-requests/

--- a/doc/source/CONTRIBUTING.rst
+++ b/doc/source/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+../../CONTRIBUTING.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,10 +13,10 @@ Contents:
 
    README
    MANUAL
+   CONTRIBUTING
    developer_guidelines
    internal_arch
    api
-
 
 
 Indices and tables


### PR DESCRIPTION
We have had a CONTRIBUTING.rst file in the repo for some time (at the
suggestion of Github) but this is not discoverable unless you can find
the repo. As pointed out in issue #218 the repo can be hard to find in
certain cases, so this document isn't always discoverable. In an effort
to fix this, this commit updates the README to include this content.
Additionally it adds the CONTRIBUTING.rst file to the rendered docs.

Fixes #218