### PR TITLE
Take care of 'concurrency is None' case

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -37,7 +37,7 @@ from stestr import user_config
 def _to_int(possible, default=0, out=sys.stderr):
     try:
         i = int(possible)
-    except ValueError:
+    except (ValueError, TypeError):
         i = default
         msg = ('Unable to convert "%s" to an integer.  Using %d.\n' %
                (possible, default))

--- a/stestr/tests/test_run.py
+++ b/stestr/tests/test_run.py
@@ -37,3 +37,12 @@ class TestRunCommand(base.TestCase):
             'Using 0.\n')
         self.assertEqual(fake_stderr.getvalue(), expected)
         self.assertEqual(0, out)
+
+    def test_to_int_none(self):
+        fake_stderr = io.StringIO()
+        out = run._to_int(None, out=fake_stderr)
+        expected = (
+            'Unable to convert "None" to an integer.  '
+            'Using 0.\n')
+        self.assertEqual(fake_stderr.getvalue(), expected)
+        self.assertEqual(0, out)


### PR DESCRIPTION
This commit fixes `concurrency is None` case. The original code was
taking care of ValueError case such as 'foo', but if we pass `None` to
the `_to_int()`, it raised a TypeError. So, this commit converts it to a
ValueError instead.