### PR TITLE
Discover python executable when discover is not used

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -348,7 +348,15 @@ def run_command(config='.stestr.conf', repo_type='file',
         if ids.find('/') != -1:
             root = ids.replace('.py', '')
             ids = root.replace('/', '.')
-        run_cmd = 'python -m subunit.run ' + ids
+        stestr_python = sys.executable
+        if os.environ.get('PYTHON'):
+            python_bin = os.environ.get('PYTHON')
+        elif stestr_python:
+            python_bin = stestr_python
+        else:
+            raise RuntimeError("The Python interpreter was not found and "
+                               "PYTHON is not set")
+        run_cmd = python_bin + ' -m subunit.run ' + ids
 
         def run_tests():
             run_proc = [('subunit', output.ReturnCodeToSubunit(


### PR DESCRIPTION
Currently it's hardcoded to 'python' wich in some cases may not exist,
as in some distros with python3 only.

This patch uses PYTHON env variable if defined or executable used to run
stestr.