### PR TITLE
Add flag to print all attachments for successful tests

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -205,6 +205,16 @@ in some cases printing these attachments on a successful tests is not the
 preferred behavior. You can use the ``--suppress-attachments`` flag to disable
 printing stdout or stderr attachments for successful tests.
 
+While by default attachments for captured stdout and stderr are printed, it
+is also possible that a test has other text attachments (a common example is
+python logging) which are not printed on successful test execution, only on
+failures. If you would like to have these attachments also printed for
+successful tests you can use the ``--all-attachments`` flag to print all text
+attachments on both successful and failed tests. If both ``--all-attachments``
+and ``--suppress-attachments`` are set then the ``--suppress--attachments``
+flag will take priority and no attachments will be printed for successful
+tests.
+
 Combining Test Results
 ----------------------
 There is sometimes a use case for running a single test suite split between
@@ -445,18 +455,21 @@ that changes the default on all available options in the config file is::
       abbreviate: True
       slowest: True
       suppress-attachments: True
+      all-attachments: True
     failing:
       list: True
     last:
       no-subunit-trace: True
       color: True
       suppress-attachments: True
+      all-attachments: True
     load:
       force-init: True
       subunit-trace: True
       color: True
       abbreviate: True
       suppress-attachments: True
+      all-attachments: True
 
 If you choose to use a user config file you can specify any subset of the
 options and commands you choose.

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -61,6 +61,10 @@ class Last(command.Command):
                             help='If set do not print stdout or stderr '
                             'attachment contents on a successful test '
                             'execution')
+        parser.add_argument('--all-attachments', action='store_true',
+                            dest='all_attachments',
+                            help='If set print all text attachment contents on'
+                            ' a successful test execution')
         return parser
 
     def take_action(self, parsed_args):
@@ -79,19 +83,24 @@ class Last(command.Command):
             suppress_attachments = (
                 args.suppress_attachments or user_conf.last.get(
                     'suppress-attachments', False))
-
+            all_attachments = (
+                args.all_attachments or user_conf.last.get(
+                    'all-attachments', False))
         else:
             pretty_out = args.force_subunit_trace or not args.no_subunit_trace
             color = args.color
             suppress_attachments = args.suppress_attachments
+            all_attachments = args.all_attachments
         return last(repo_type=self.app_args.repo_type,
                     repo_url=self.app_args.repo_url,
                     subunit_out=args.subunit, pretty_out=pretty_out,
-                    color=color, suppress_attachments=suppress_attachments)
+                    color=color, suppress_attachments=suppress_attachments,
+                    all_attachments=all_attachments)
 
 
 def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
-         color=False, stdout=sys.stdout, suppress_attachments=False):
+         color=False, stdout=sys.stdout, suppress_attachments=False,
+         all_attachments=False):
     """Show the last run loaded into a a repository
 
     This function will print the results from the last run in the repository
@@ -113,6 +122,8 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
          this is sys.stdout
     :param bool suppress_attachments: When set true attachments subunit_trace
         will not print attachments on successful test execution.
+    :param bool all_attachments: When set true subunit_trace will print all
+        text attachments on successful test execution.
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -160,7 +171,8 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
         stream = latest_run.get_subunit_stream()
         failed = subunit_trace.trace(stream, stdout, post_fails=True,
                                      color=color,
-                                     suppress_attachments=suppress_attachments)
+                                     suppress_attachments=suppress_attachments,
+                                     all_attachments=all_attachments)
     if failed:
         return 1
     else:

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -152,6 +152,10 @@ class Run(command.Command):
                             help='If set do not print stdout or stderr '
                             'attachment contents on a successful test '
                             'execution')
+        parser.add_argument('--all-attachments', action='store_true',
+                            dest='all_attachments',
+                            help='If set print all text attachment contents on'
+                            ' a successful test execution')
         return parser
 
     def take_action(self, parsed_args):
@@ -179,6 +183,10 @@ class Run(command.Command):
             suppress_attachments = (
                 args.suppress_attachments or user_conf.run.get(
                     'suppress-attachments', False))
+            all_attachments = (
+                args.all_attachments or user_conf.run.get(
+                    'all-attachments', False))
+
         else:
             pretty_out = args.force_subunit_trace or not args.no_subunit_trace
             concurrency = args.concurrency or 0
@@ -186,6 +194,7 @@ class Run(command.Command):
             color = args.color
             abbreviate = args.abbreviate
             suppress_attachments = args.suppress_attachments
+            all_attachments = args.all_attachments
         verbose_level = self.app.options.verbose_level
         stdout = open(os.devnull, 'w') if verbose_level == 0 else sys.stdout
         # Make sure all (python) callers have provided an int()
@@ -210,7 +219,8 @@ class Run(command.Command):
             combine=args.combine,
             filters=filters, pretty_out=pretty_out, color=color,
             stdout=stdout, abbreviate=abbreviate,
-            suppress_attachments=suppress_attachments)
+            suppress_attachments=suppress_attachments,
+            all_attachments=all_attachments)
 
         # Always output slowest test info if requested, regardless of other
         # test run options
@@ -250,7 +260,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                 blacklist_file=None, whitelist_file=None, black_regex=None,
                 no_discover=False, random=False, combine=False, filters=None,
                 pretty_out=True, color=False, stdout=sys.stdout,
-                abbreviate=False, suppress_attachments=False):
+                abbreviate=False, suppress_attachments=False,
+                all_attachments=False):
     """Function to execute the run command
 
     This function implements the run command. It will run the tests specified
@@ -311,6 +322,8 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param bool abbreviate: Use abbreviated output if set true
     :param bool suppress_attachments: When set true attachments subunit_trace
         will not print attachments on successful test execution.
+    :param bool all_attachments: When set true subunit_trace will print all
+        text attachments on successful test execution.
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -368,7 +381,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                              repo_url=repo_url, run_id=combine_id,
                              pretty_out=pretty_out,
                              color=color, stdout=stdout, abbreviate=abbreviate,
-                             suppress_attachments=suppress_attachments)
+                             suppress_attachments=suppress_attachments,
+                             all_attachments=all_attachments)
 
         if not until_failure:
             return run_tests()
@@ -439,7 +453,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                     subunit_out=subunit_out, combine_id=combine_id,
                     repo_type=repo_type, repo_url=repo_url,
                     pretty_out=pretty_out, color=color, abbreviate=abbreviate,
-                    stdout=stdout, suppress_attachments=suppress_attachments)
+                    stdout=stdout, suppress_attachments=suppress_attachments,
+                    all_attachments=all_attachments)
                 if run_result > result:
                     result = run_result
             return result
@@ -453,7 +468,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                               color=color,
                               stdout=stdout,
                               abbreviate=abbreviate,
-                              suppress_attachments=suppress_attachments)
+                              suppress_attachments=suppress_attachments,
+                              all_attachments=all_attachments)
     else:
         # Where do we source data about the cause of conflicts.
         latest_run = repo.get_latest_run()
@@ -497,7 +513,8 @@ def run_command(config='.stestr.conf', repo_type='file',
 def _run_tests(cmd, until_failure,
                subunit_out=False, combine_id=None, repo_type='file',
                repo_url=None, pretty_out=True, color=False, stdout=sys.stdout,
-               abbreviate=False, suppress_attachments=False):
+               abbreviate=False, suppress_attachments=False,
+               all_attachments=False):
     """Run the tests cmd was parameterised with."""
     cmd.setUp()
     try:
@@ -514,7 +531,8 @@ def _run_tests(cmd, until_failure,
                              repo_url=repo_url, run_id=combine_id,
                              pretty_out=pretty_out, color=color, stdout=stdout,
                              abbreviate=abbreviate,
-                             suppress_attachments=suppress_attachments)
+                             suppress_attachments=suppress_attachments,
+                             all_attachments=all_attachments)
 
         if not until_failure:
             return run_tests()

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -152,7 +152,8 @@ def find_test_run_time_diff(test_id, run_time):
 
 def show_outcome(stream, test, print_failures=False, failonly=False,
                  enable_diff=False, threshold='0', abbreviate=False,
-                 enable_color=False, suppress_attachments=False):
+                 enable_color=False, suppress_attachments=False,
+                 all_attachments=False):
     global RESULTS
     status = test['status']
     # TODO(sdague): ask lifeless why on this?
@@ -207,7 +208,10 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
                 color.write('ok', 'green')
                 stream.write('\n')
                 if not suppress_attachments:
-                    print_attachments(stream, test)
+                    if not all_attachments:
+                        print_attachments(stream, test)
+                    else:
+                        print_attachments(stream, test, all_channels=True)
         elif status == 'skip':
             if abbreviate:
                 color.write('S', 'blue')
@@ -351,7 +355,7 @@ def parse_args():
 
 def trace(stdin, stdout, print_failures=False, failonly=False,
           enable_diff=False, abbreviate=False, color=False, post_fails=False,
-          no_summary=False, suppress_attachments=False):
+          no_summary=False, suppress_attachments=False, all_attachments=False):
     stream = subunit.ByteStreamToStreamResult(
         stdin, non_subunit_name='stdout')
     outcomes = testtools.StreamToDict(
@@ -361,7 +365,8 @@ def trace(stdin, stdout, print_failures=False, failonly=False,
                           enable_diff=enable_diff,
                           abbreviate=abbreviate,
                           enable_color=color,
-                          suppress_attachments=suppress_attachments))
+                          suppress_attachments=suppress_attachments,
+                          all_attachments=all_attachments))
     summary = testtools.StreamSummary()
     result = testtools.CopyStreamResult([outcomes, summary])
     result = testtools.StreamResultRouter(result)

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -27,18 +27,21 @@ run:
   abbreviate: True
   slowest: True
   suppress-attachments: True
+  all-attachments: True
 failing:
   list: True
 last:
   no-subunit-trace: True
   color: True
   suppress-attachments: True
+  all-attachments: True
 load:
   force-init: True
   subunit-trace: True
   color: True
   abbreviate: True
   suppress-attachments: True
+  all-attachments: True
 """
 
 INVALID_YAML_FIELD = """
@@ -135,19 +138,22 @@ class TestUserConfig(base.TestCase):
                 'color': True,
                 'abbreviate': True,
                 'slowest': True,
-                'suppress-attachments': True},
+                'suppress-attachments': True,
+                'all-attachments': True},
             'failing': {
                 'list': True},
             'last': {
                 'no-subunit-trace': True,
                 'color': True,
-                'suppress-attachments': True},
+                'suppress-attachments': True,
+                'all-attachments': True},
             'load': {
                 'force-init': True,
                 'subunit-trace': True,
                 'color': True,
                 'abbreviate': True,
-                'suppress-attachments': True}
+                'suppress-attachments': True,
+                'all-attachments': True}
         }
         self.assertEqual(full_dict, user_conf.config)
 

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -48,6 +48,7 @@ class UserConfig(object):
                 vp.Optional('abbreviate'): bool,
                 vp.Optional('slowest'): bool,
                 vp.Optional('suppress-attachments'): bool,
+                vp.Optional('all-attachments'): bool,
             },
             vp.Optional('failing'): {
                 vp.Optional('list'): bool,
@@ -56,6 +57,7 @@ class UserConfig(object):
                 vp.Optional('no-subunit-trace'): bool,
                 vp.Optional('color'): bool,
                 vp.Optional('suppress-attachments'): bool,
+                vp.Optional('all-attachments'): bool,
             },
             vp.Optional('load'): {
                 vp.Optional('force-init'): bool,
@@ -63,6 +65,7 @@ class UserConfig(object):
                 vp.Optional('color'): bool,
                 vp.Optional('abbreviate'): bool,
                 vp.Optional('suppress-attachments'): bool,
+                vp.Optional('all-attachments'): bool,
             }
         })
         with open(path, 'r') as fd:


### PR DESCRIPTION
This commit adds a new flag, --all-attachments, to the run, load, and
last commands (in addition to a matching user config flag). When set
this flag will tell subunit trace to print all text attachments for a
test whether it was successful or it failed.

Fixes #223