### PR TITLE
Don't install sphinx in python2 jobs

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 hacking<0.12,>=0.11.0 # Apache-2.0
-sphinx>=1.5.1 # BSD
+sphinx>=1.5.1; python_version>3.4 # BSD
 mock>=2.0 # BSD
 subunit2sql>=1.8.0
 coverage>=4.0 # Apache-2.0


### PR DESCRIPTION
Sphinx >=2.0.0 has dropped support for python2 (and python 3.4) we
already build our docs using python 3 but sphinx was always being
installed in our python2 ci jobs. This commit adds a minimum python
version to the test-requirements.txt file so that we no longer attempt
to install sphinx on an unsupported python version.