### PR TITLE
Cap sphinx version <2.0.0 when python2.7

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,8 @@
 # process, which may cause wedges in the gate later.
 
 hacking<0.12,>=0.11.0 # Apache-2.0
-sphinx>=1.5.1 # BSD
+sphinx!=1.6.6,!=1.6.7,<2.0.0;python_version=='2.7'  # BSD
+sphinx!=1.6.6,!=1.6.7,!=2.1.0;python_version>='3.4'  # BSD
 mock>=2.0 # BSD
 subunit2sql>=1.8.0
 coverage>=4.0 # Apache-2.0


### PR DESCRIPTION
This commit caps and limits the sphinx version which causes errors.
Especially, the version from 2.0.0 is not compatible with python2.7.
We are planning to drop our support for python2.7 next year but we still
need to support it at this point.