### PR TITLE
Rework logic for suppress attachments and all attachments

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -210,10 +210,12 @@ is also possible that a test has other text attachments (a common example is
 python logging) which are not printed on successful test execution, only on
 failures. If you would like to have these attachments also printed for
 successful tests you can use the ``--all-attachments`` flag to print all text
-attachments on both successful and failed tests. If both ``--all-attachments``
-and ``--suppress-attachments`` are set then the ``--suppress--attachments``
-flag will take priority and no attachments will be printed for successful
-tests.
+attachments on both successful and failed tests. Both ``--all-attachments``
+and ``--suppress-attachments`` can not be set at the same time. If both are
+set in the user config file then the ``suppress-attachments`` flag will take
+priority and no attachments will be printed for successful tests. If either
+``--suppress-attachments`` or ``--all-attachments`` is set via the CLI it
+will take precedence over matching options set in the user config file.
 
 Combining Test Results
 ----------------------

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -70,6 +70,12 @@ class Last(command.Command):
     def take_action(self, parsed_args):
         user_conf = user_config.get_user_config(self.app_args.user_config)
         args = parsed_args
+        if args.suppress_attachments and args.all_attachments:
+            msg = ("The --suppress-attachments and --all-attachments "
+                   "options are mutually exclusive, you can not use both "
+                   "at the same time")
+            print(msg)
+            sys.exit(1)
         if getattr(user_conf, 'last', False):
             if not user_conf.last.get('no-subunit-trace'):
                 if not args.no_subunit_trace:
@@ -80,12 +86,19 @@ class Last(command.Command):
                 pretty_out = False
             pretty_out = args.force_subunit_trace or pretty_out
             color = args.color or user_conf.last.get('color', False)
-            suppress_attachments = (
-                args.suppress_attachments or user_conf.last.get(
-                    'suppress-attachments', False))
-            all_attachments = (
-                args.all_attachments or user_conf.last.get(
-                    'all-attachments', False))
+            suppress_attachments_conf = user_conf.run.get(
+                'suppress-attachments', False)
+            all_attachments_conf = user_conf.run.get(
+                'all-attachments', False)
+            if not args.suppress_attachments and not args.all_attachments:
+                suppress_attachments = suppress_attachments_conf
+                all_attachments = all_attachments_conf
+            elif args.suppress_attachments:
+                all_attachments = False
+                suppress_attachments = args.suppress_attachments
+            elif args.all_attachments:
+                suppress_attachments = False
+                all_attachments = args.all_attachments
         else:
             pretty_out = args.force_subunit_trace or not args.no_subunit_trace
             color = args.color

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -90,6 +90,12 @@ class Load(command.Command):
     def take_action(self, parsed_args):
         user_conf = user_config.get_user_config(self.app_args.user_config)
         args = parsed_args
+        if args.suppress_attachments and args.all_attachments:
+            msg = ("The --suppress-attachments and --all-attachments "
+                   "options are mutually exclusive, you can not use both "
+                   "at the same time")
+            print(msg)
+            sys.exit(1)
         if getattr(user_conf, 'load', False):
             force_init = args.force_init or user_conf.load.get('force-init',
                                                                False)
@@ -98,12 +104,19 @@ class Load(command.Command):
             color = args.color or user_conf.load.get('color', False)
             abbreviate = args.abbreviate or user_conf.load.get('abbreviate',
                                                                False)
-            suppress_attachments = (
-                args.suppress_attachments or user_conf.load.get(
-                    'suppress-attachments', False))
-            all_attachments = (
-                args.all_attachments or user_conf.load.get(
-                    'all-attachments', False))
+            suppress_attachments_conf = user_conf.run.get(
+                'suppress-attachments', False)
+            all_attachments_conf = user_conf.run.get(
+                'all-attachments', False)
+            if not args.suppress_attachments and not args.all_attachments:
+                suppress_attachments = suppress_attachments_conf
+                all_attachments = all_attachments_conf
+            elif args.suppress_attachments:
+                all_attachments = False
+                suppress_attachments = args.suppress_attachments
+            elif args.all_attachments:
+                suppress_attachments = False
+                all_attachments = args.all_attachments
         else:
             force_init = args.force_init
             pretty_out = args.subunit_trace

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -162,6 +162,12 @@ class Run(command.Command):
         user_conf = user_config.get_user_config(self.app_args.user_config)
         filters = parsed_args.filters
         args = parsed_args
+        if args.suppress_attachments and args.all_attachments:
+            msg = ("The --suppress-attachments and --all-attachments "
+                   "options are mutually exclusive, you can not use both "
+                   "at the same time")
+            print(msg)
+            sys.exit(1)
         if getattr(user_conf, 'run', False):
             if not user_conf.run.get('no-subunit-trace'):
                 if not args.no_subunit_trace:
@@ -180,13 +186,19 @@ class Run(command.Command):
             color = args.color or user_conf.run.get('color', False)
             abbreviate = args.abbreviate or user_conf.run.get(
                 'abbreviate', False)
-            suppress_attachments = (
-                args.suppress_attachments or user_conf.run.get(
-                    'suppress-attachments', False))
-            all_attachments = (
-                args.all_attachments or user_conf.run.get(
-                    'all-attachments', False))
-
+            suppress_attachments_conf = user_conf.run.get(
+                'suppress-attachments', False)
+            all_attachments_conf = user_conf.run.get(
+                'all-attachments', False)
+            if not args.suppress_attachments and not args.all_attachments:
+                suppress_attachments = suppress_attachments_conf
+                all_attachments = all_attachments_conf
+            elif args.suppress_attachments:
+                all_attachments = False
+                suppress_attachments = args.suppress_attachments
+            elif args.all_attachments:
+                suppress_attachments = False
+                all_attachments = args.all_attachments
         else:
             pretty_out = args.force_subunit_trace or not args.no_subunit_trace
             concurrency = args.concurrency or 0


### PR DESCRIPTION
This commit reworks the logic for handling the 2 mutually exclusive
options suppress attachments and all attachments. Previosuly supress
attachments would always take precedence over all attachments, even if
all attachments were set via the cli and all attachments were in the
user config file. This commit makes the behavior more consistent with
expectations and has it so cli arguments always take precedence. It also
changes the behavior to error if both options are set on the cli.