### PR TITLE
Add readme note about python 2 eol in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ stestr
 * You can see the full rendered docs at: http://stestr.readthedocs.io/en/latest/
 * The code of the project is on Github: https://github.com/mtreinish/stestr
 
+.. note:: stestr v2.x.x release series will be the last series that supports
+    Python 2. Support for Python 2.7 will be dropped in stestr release 3.0.0
+    which is being planned for early 2020.
+
 Overview
 --------
 

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import sys
+import warnings
 
 from cliff import app
 from cliff import commandmanager
@@ -107,6 +108,12 @@ class StestrCLI(app.App):
 
 
 def main(argv=sys.argv[1:]):
+    if sys.version_info[:2] == (2, 7):
+        msg = (
+            "Python 2.7 will reach the end of its life on January 1st, 2020. "
+            "Support for using python 2.7 with stestr will be removed in the "
+            "3.0.0 release in early 2020")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     cli = StestrCLI()
     return cli.run(argv)
 


### PR DESCRIPTION
Now that we're getting ready to drop python 2 support for an stestr
3.0.0 release in early 2020 this commit adds a release note to make the
plans clear to end users.