### PR TITLE
Add release automation for pypi artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ matrix:
       env: TOXENV=docs
     - python: "2.7"
       env: TOXENV=py27
+    - if: tag IS present
+      python: "3.6"
+      env:
+        - TWINE_USERNAME=stestr-release
+      install: pip install -U twine
+      script:
+        - python3 setup.py sdist bdist_wheel --universal
+        - twine upload dist/stestr*
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ stestr.cm =
 sql =
     subunit2sql>=1.8.0
 
+[bdist_wheel]
+universal=1
+
 [build_sphinx]
 source-dir = doc/source
 build-dir = doc/build


### PR DESCRIPTION
This commit adds travis jobs on tag releases to build the release
artifacts for pypi. It will generate both an sdist and a universal
wheel and then upload that to pypi. This automates the release process
so that when it's release time we only need to push a tag to github
and everything else is handled automatically.