### PR TITLE
Unskip get/find metadata tests

### DIFF
--- a/stestr/tests/repository/test_sql.py
+++ b/stestr/tests/repository/test_sql.py
@@ -82,7 +82,6 @@ class TestSqlRepository(base.TestCase):
         self.assertTrue(stream.readable())
         self.assertEqual([], stream.readlines())
 
-    @testtools.skipIf(os.name == 'nt', 'tempfile fails on appveyor')
     def test_get_metadata(self):
         repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
         result = repo.get_inserter(metadata='fun')
@@ -91,7 +90,6 @@ class TestSqlRepository(base.TestCase):
         run = repo.get_test_run(result.get_id())
         self.assertEqual('fun', run.get_metadata())
 
-    @testtools.skipIf(os.name == 'nt', 'tempfile fails on appveyor')
     def test_find_metadata(self):
         repo = self.useFixture(SqlRepositoryFixture(url=self.url)).repo
         result = repo.get_inserter(metadata='fun')


### PR DESCRIPTION
This commit makes the tests unskip since we moved windows tests to the
Azure pipeline environment. The root cause of failure was unknown on the
appveyor environment. So, these would work in the new environment
hopefully.