### PR TITLE
Add macOS py37 azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,33 +6,57 @@
 trigger:
 - master
 
-pool:
-  vmImage: 'vs2017-win2016'
-strategy:
-  matrix:
-    Python27:
-      python.version: '2.7'
-    Python35:
-      python.version: '3.5'
-    Python36:
-      python.version: '3.6'
-    Python37:
-      python.version: '3.7'
+jobs:
+- job: 'Windows_Tests'
+  pool: {vmImage: 'vs2017-win2016'}
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
 
-steps:
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '$(python.version)'
-  displayName: 'Use Python $(python.version)'
+  - script: choco install vcpython27 --yes
+    condition: eq(variables['python.version'], '2.7')
+    displayName: 'Install vcpython27'
 
-- script: choco install vcpython27 --yes
-  condition: eq(variables['python.version'], '2.7')
-  displayName: 'Install vcpython27'
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -U tox
+    displayName: 'Install dependencies'
+  - script: tox -e py
+    displayName: 'Run Tox'
 
-- script: |
-    python -m pip install --upgrade pip
-    pip install -U tox
-  displayName: 'Install dependencies'
+- job: 'macOS_Tests'
+  pool: {vmImage: 'macOS-10.14'}
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
 
-- script: tox -e py
-  displayName: 'Run Tox'
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -U tox
+    displayName: 'Install dependencies'
+  - script: tox -e py
+    displayName: 'Run Tox'


### PR DESCRIPTION
This commit adds a macOS Mojave(10.14) testing job strategy to the azure
pipelines. In the document[0], it supports macOS 10.14 and 10.13 but we
don't need to test all versions of macOS and Python. So, as a first
step, this commit just add one job.

[0] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent