### PR TITLE
Mention IRC channel in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,3 +137,12 @@ This will run the test suite and also the automated style rule checks just as
 they will in CI. If CI fails on your change it will not be able to merge.
 
 .. _github pull requests: https://help.github.com/articles/about-pull-requests/
+
+Community
+---------
+
+Besides Github interactions there is also a stestr IRC channel:
+
+#stestr on Freenode
+
+feel free to join to ask questions, or just discuss stestr.


### PR DESCRIPTION
This commit adds a note about the project's IRC channel to the README
file. The channel is very inactive and that's likely because no one
knows that it exists. It's good to have a place to ask a question about
the project in real time, so this commit adds a note about the channel
to advertise that it exists and is a place to discuss all things
stestr.