### PR TITLE
Fix edge case where there are no test times in output

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -275,6 +275,9 @@ def _load_case(inserter, repo, case, subunit_out, pretty_out,
                 x['timestamps'][0] for x in subunit_trace.RESULTS[worker]]
             stop_times += [
                 x['timestamps'][1] for x in subunit_trace.RESULTS[worker]]
+        if not start_times or not stop_times:
+            sys.stderr.write("\nNo tests were successful during the run")
+            return 1
         start_time = min(start_times)
         stop_time = max(stop_times)
         elapsed_time = stop_time - start_time

--- a/stestr/tests/test_load.py
+++ b/stestr/tests/test_load.py
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import io
+
+from stestr.commands import load
+from stestr.tests import base
+
+
+class TestLoadCommand(base.TestCase):
+    def test_empty_with_pretty_out(self):
+        stream = io.BytesIO()
+        output = io.BytesIO()
+        res = load.load(in_streams=[('subunit', stream)], pretty_out=True,
+                        stdout=output)
+        self.assertEqual(1, res)


### PR DESCRIPTION
This commit fixes an edge case with the load command when there are no
test events in the subunit stream being passed to load. If the
pretty_out flag is set for the load command and there is no subunit
output the processing being used to handle the test run timing will fail
because there are no tests. This fixes that by just returning the test
run failed (because there were no sucessful tests run).

Fixes #244