### PR TITLE
Add custom test runner and remove testtools runner dependency

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -102,7 +102,7 @@ import paths) For example::
 
   $ stestr run --no-discover project/tests/test_foo.py
 
-will also bypass discovery and directly call subunit.run on the module
+will also bypass discovery and directly call the test runner on the module
 specified.
 
 Additionally you can specify a specific class or method within that file using
@@ -110,7 +110,7 @@ Additionally you can specify a specific class or method within that file using
 
   $ stestr run --no-discover project/tests/test_foo.py::TestFoo::test_method
 
-will skip discovery and directly call subunit.run on the test method in the
+will skip discovery and directly call the test runner on the test method in the
 specified test class.
 
 Test Selection

--- a/doc/source/internal_arch.rst
+++ b/doc/source/internal_arch.rst
@@ -72,12 +72,12 @@ Operations for Running Tests
 
 The basic flow when stestr run is called at a high level is fairly straight
 forward. In the default case when run is called the first operation performed
-is unittest discovery (via ``subunit.run --discover``) which is used to get a
-complete list of tests present. This list is then filtered by any user provided
-selection mechanisms. (for example a cli regex filter) This is used to select
-which tests the user actually intends to run. For more details on test
-selection see: :ref:`api_selection` which defines the functions which are used
-to actually perform the filtering.
+is unittest discovery which is used to get a complete list of tests present.
+This list is then filtered by any user provided selection mechanisms. (for
+example a cli regex filter) This is used to select which tests the user
+actually intends to run. For more details on test selection see:
+:ref:`api_selection` which defines the functions which are used to actually
+perform the filtering.
 
 Once there is complete list of tests that will be run the list gets passed
 to the scheduler/partitioner. The scheduler takes the list of tests and splits
@@ -89,7 +89,7 @@ For the full details on how the partitioning is performed see:
 
 With the tests split into multiple groups for each worker process we're
 ready to start executing the tests. Each group of tests is used to launch a
-subunit.run worker subprocess. As the name implies this is a test runner that
+test runner worker subprocess. As the name implies this is a test runner that
 emits a subunit stream to stdout. These stdout streams are combined in real
 time and stored in the repository at the end of the run (using the load
 command). The combined stream is also used for the CLI output either in a

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages =
 [entry_points]
 console_scripts =
     stestr = stestr.cli:main
-
+    stestr-subunit-run = stestr.subunit_runner.run:main
 stestr.cm =
     run = stestr.commands.run:Run
     failing = stestr.commands.failing:Failing

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ packages =
 [entry_points]
 console_scripts =
     stestr = stestr.cli:main
-    stestr-subunit-run = stestr.subunit_runner.run:main
 stestr.cm =
     run = stestr.commands.run:Run
     failing = stestr.commands.failing:Failing

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -381,7 +381,7 @@ def run_command(config='.stestr.conf', repo_type='file',
         else:
             raise RuntimeError("The Python interpreter was not found and "
                                "PYTHON is not set")
-        run_cmd = python_bin + ' -m subunit.run ' + ids
+        run_cmd = python_bin + ' -m stestr.subunit_runner.run ' + ids
 
         def run_tests():
             run_proc = [('subunit', output.ReturnCodeToSubunit(

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -120,7 +120,7 @@ class TestrConf(object):
                 raise RuntimeError("The Python interpreter was not found and "
                                    "PYTHON is not set")
 
-        command = '%s -m subunit.run discover -t "%s" "%s" ' \
+        command = '%s -m stestr.subunit_runner.run discover -t "%s" "%s" ' \
                   '$LISTOPT $IDOPTION' % (python, top_dir, test_path)
         listopt = "--list"
         idoption = "--load-list $IDFILE"

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -1,0 +1,248 @@
+# Copyright 2019 Matthew Treinish
+# Copyright (c) 2009 testtools developers.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import functools
+import os
+import sys
+import unittest
+
+import extras
+
+defaultTestLoader = unittest.defaultTestLoader
+defaultTestLoaderCls = unittest.TestLoader
+have_discover = True
+
+# Kept for API compatibility, but no longer used.
+BUFFEROUTPUT = ""
+CATCHBREAK = ""
+FAILFAST = ""
+USAGE_AS_MAIN = ""
+
+
+def filter_by_ids(suite_or_case, test_ids):
+    """Remove tests from suite_or_case where their id is not in test_ids.
+
+    :param suite_or_case: A test suite or test case.
+    :param test_ids: Something that supports the __contains__ protocol.
+    :return: suite_or_case, unless suite_or_case was a case that itself
+        fails the predicate when it will return a new unittest.TestSuite with
+        no contents.
+
+    For subclasses of TestSuite, filtering is done by:
+        - attempting to call suite.filter_by_ids(test_ids)
+        - if there is no method, iterating the suite and identifying tests to
+          remove, then removing them from _tests, manually recursing into
+          each entry.
+
+    For objects with an id() method - TestCases, filtering is done by:
+        - attempting to return case.filter_by_ids(test_ids)
+        - if there is no such method, checking for case.id() in test_ids
+          and returning case if it is, or TestSuite() if it is not.
+
+    For anything else, it is not filtered - it is returned as-is.
+
+    To provide compatibility with this routine for a custom TestSuite, just
+    define a filter_by_ids() method that will return a TestSuite equivalent to
+    the original minus any tests not in test_ids.
+    Similarly to provide compatibility for a custom TestCase that does
+    something unusual define filter_by_ids to return a new TestCase object
+    that will only run test_ids that are in the provided container. If none
+    would run, return an empty TestSuite().
+
+    The contract for this function does not require mutation - each filtered
+    object can choose to return a new object with the filtered tests. However
+    because existing custom TestSuite classes in the wild do not have this
+    method, we need a way to copy their state correctly which is tricky:
+    thus the backwards-compatible code paths attempt to mutate in place rather
+    than guessing how to reconstruct a new suite.
+    """
+    # Compatible objects
+    if extras.safe_hasattr(suite_or_case, 'filter_by_ids'):
+        return suite_or_case.filter_by_ids(test_ids)
+    # TestCase objects.
+    if extras.safe_hasattr(suite_or_case, 'id'):
+        if suite_or_case.id() in test_ids:
+            return suite_or_case
+        else:
+            return unittest.TestSuite()
+    # Standard TestSuites or derived classes [assumed to be mutable].
+    if isinstance(suite_or_case, unittest.TestSuite):
+        filtered = []
+        for item in suite_or_case:
+            filtered.append(filter_by_ids(item, test_ids))
+        suite_or_case._tests[:] = filtered
+    # Everything else:
+    return suite_or_case
+
+
+def iterate_tests(test_suite_or_case):
+    """Iterate through all of the test cases in 'test_suite_or_case'."""
+    try:
+        suite = iter(test_suite_or_case)
+    except TypeError:
+        yield test_suite_or_case
+    else:
+        for test in suite:
+            for subtest in iterate_tests(test):
+                yield subtest
+
+
+def list_test(test):
+    """Return the test ids that would be run if test() was run.
+
+    When things fail to import they can be represented as well, though
+    we use an ugly hack (see http://bugs.python.org/issue19746 for details)
+    to determine that. The difference matters because if a user is
+    filtering tests to run on the returned ids, a failed import can reduce
+    the visible tests but it can be impossible to tell that the selected
+    test would have been one of the imported ones.
+
+    :return: A tuple of test ids that would run and error strings
+        describing things that failed to import.
+    """
+    unittest_import_strs = set([
+        'unittest2.loader.ModuleImportFailure.',
+        'unittest.loader.ModuleImportFailure.',
+        'discover.ModuleImportFailure.'
+        ])
+    test_ids = []
+    errors = []
+    for test in iterate_tests(test):
+        # Much ugly.
+        for prefix in unittest_import_strs:
+            if test.id().startswith(prefix):
+                errors.append(test.id()[len(prefix):])
+                break
+        else:
+            test_ids.append(test.id())
+    return test_ids, errors
+
+
+class TestProgram(unittest.TestProgram):
+
+    # defaults for testing
+    module = None
+    verbosity = 1
+    failfast = catchbreak = buffer = progName = None
+    _discovery_parser = None
+
+    def __init__(self, module='__main__', defaultTest=None, argv=None,
+                 testRunner=None, testLoader=defaultTestLoader,
+                 exit=True, verbosity=1, failfast=None, catchbreak=None,
+                 buffer=None, warnings=None, tb_locals=False):
+        if isinstance(module, str):
+            self.module = __import__(module)
+            for part in module.split('.')[1:]:
+                self.module = getattr(self.module, part)
+        else:
+            self.module = module
+        if argv is None:
+            argv = sys.argv
+
+        self.exit = exit
+        self.failfast = failfast
+        self.catchbreak = catchbreak
+        self.verbosity = verbosity
+        self.buffer = buffer
+        self.tb_locals = tb_locals
+        if warnings is None and not sys.warnoptions:
+            # even if DeprecationWarnings are ignored by default
+            # print them anyway unless other warnings settings are
+            # specified by the warnings arg or the -W python flag
+            self.warnings = 'default'
+        else:
+            # here self.warnings is set either to the value passed
+            # to the warnings args or to None.
+            # If the user didn't pass a value self.warnings will
+            # be None. This means that the behavior is unchanged
+            # and depends on the values passed to -W.
+            self.warnings = warnings
+        self.defaultTest = defaultTest
+        # XXX: Local edit (see http://bugs.python.org/issue22860)
+        self.listtests = False
+        self.load_list = None
+        self.testRunner = testRunner
+        self.testLoader = testLoader
+        self.progName = os.path.basename(argv[0])
+        self.parseArgs(argv)
+        # XXX: Local edit (see http://bugs.python.org/issue22860)
+        if self.load_list:
+            # TODO(mtreinish): preserve existing suites (like testresources
+            # does in OptimisingTestSuite.add, but with a standard protocol).
+            # This is needed because the load_tests hook allows arbitrary
+            # suites, even if that is rarely used.
+            source = open(self.load_list, 'rb')
+            try:
+                lines = source.readlines()
+            finally:
+                source.close()
+            test_ids = set(line.strip().decode('utf-8') for line in lines)
+            self.test = filter_by_ids(self.test, test_ids)
+        # XXX: Local edit (see http://bugs.python.org/issue22860)
+        if not self.listtests:
+            self.runTests()
+        else:
+            runner = self._get_runner()
+            if extras.safe_hasattr(runner, 'list'):
+                try:
+                    runner.list(self.test, loader=self.testLoader)
+                except TypeError:
+                    runner.list(self.test)
+            else:
+                for test in iterate_tests(self.test):
+                    sys.stdout.write('%s\n' % test.id())
+
+    def _getParentArgParser(self):
+        parser = super(TestProgram, self)._getParentArgParser()
+        # XXX: Local edit (see http://bugs.python.org/issue22860)
+        parser.add_argument(
+            '-l', '--list', dest='listtests', default=False,
+            action='store_true', help='List tests rather than executing them')
+        parser.add_argument(
+            '--load-list', dest='load_list', default=None,
+            help='Specifies a file containing test ids, only tests matching '
+                 'those ids are executed')
+        return parser
+
+    def _get_runner(self):
+        testRunner = self.testRunner
+        if isinstance(self.testRunner, type):
+            try:
+                try:
+                    testRunner = self.testRunner(verbosity=self.verbosity,
+                                                 failfast=self.failfast,
+                                                 buffer=self.buffer,
+                                                 warnings=self.warnings,
+                                                 tb_locals=self.tb_locals)
+                except TypeError:
+                    # didn't accept the tb_locals argument
+                    testRunner = self.testRunner(verbosity=self.verbosity,
+                                                 failfast=self.failfast,
+                                                 buffer=self.buffer,
+                                                 warnings=self.warnings)
+            except TypeError:
+                # didn't accept the verbosity, buffer or failfast arguments
+                testRunner = self.testRunner()
+        if isinstance(testRunner, functools.partial):
+            testRunner = self.testRunner()
+        return testRunner
+
+    def runTests(self):
+        if self.catchbreak:
+            unittest.installHandler()
+        testRunner = self._get_runner()
+        self.result = testRunner.run(self.test)
+        if self.exit:
+            sys.exit(not self.result.wasSuccessful())

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -213,11 +213,15 @@ class TestProgram(unittest.TestProgram):
 
     def _get_runner(self):
         testRunner = self.testRunner
-        try:
-            testRunner = self.testRunner(failfast=self.failfast,
-                                         tb_locals=self.tb_locals)
-        except TypeError:
-            testRunner = self.testRunner()
+        if isinstance(self.testRunner, type):
+            try:
+                try:
+                    testRunner = self.testRunner(failfast=self.failfast,
+                                                 tb_locals=self.tb_locals)
+                except TypeError:
+                    testRunner = self.testRunner(failfast=self.failfast)
+            except TypeError:
+                testRunner = self.testRunner()
         # If for some reason we failed to initialize the runner initialize
         # with defaults
         if isinstance(testRunner, functools.partial):

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -206,11 +206,6 @@ class TestProgram(unittest.TestProgram):
                  'those ids are executed')
         return parser
 
-    def usageExit(self, msg=None):
-        if msg is None:
-            msg = "Internal stestr test runner"
-        super(TestProgram, self).usageExit(msg)
-
     def _get_runner(self):
         testRunner = self.testRunner
         try:

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -213,15 +213,11 @@ class TestProgram(unittest.TestProgram):
 
     def _get_runner(self):
         testRunner = self.testRunner
-        if isinstance(self.testRunner, type):
-            try:
-                try:
-                    testRunner = self.testRunner(failfast=self.failfast,
-                                                 tb_locals=self.tb_locals)
-                except TypeError:
-                    testRunner = self.testRunner(failfast=self.failfast)
-            except TypeError:
-                testRunner = self.testRunner()
+        try:
+            testRunner = self.testRunner(failfast=self.failfast,
+                                         tb_locals=self.tb_locals)
+        except TypeError:
+            testRunner = self.testRunner()
         # If for some reason we failed to initialize the runner initialize
         # with defaults
         if isinstance(testRunner, functools.partial):

--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -1,0 +1,127 @@
+# Copyright 2019 Matthew Treinish
+# Copyright (C) Jelmer Vernooij <jelmer@samba.org> 2007
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from functools import partial
+import os
+import sys
+
+from subunit import StreamResultToBytes
+from subunit.test_results import AutoTimingTestResultDecorator
+from testtools import ExtendedToStreamDecorator
+
+from stestr.subunit_runner import program
+
+
+class SubunitTestRunner(object):
+    def __init__(self, verbosity=None, failfast=None, buffer=None,
+                 stream=None, stdout=None, tb_locals=False):
+        """Create a Test Runner.
+
+        :param verbosity: Ignored.
+        :param failfast: Stop running tests at the first failure.
+        :param buffer: Ignored.
+        :param stream: Upstream unittest stream parameter.
+        :param stdout: Testtools stream parameter.
+        :param tb_locals: Testtools traceback in locals parameter.
+
+        Either stream or stdout can be supplied, and stream will take
+        precedence.
+        """
+        self.failfast = failfast
+        self.stream = stream or stdout or sys.stdout
+        self.tb_locals = tb_locals
+
+    def run(self, test):
+        "Run the given test case or test suite."
+        result, _ = self._list(test)
+        result = ExtendedToStreamDecorator(result)
+        result = AutoTimingTestResultDecorator(result)
+        if self.failfast is not None:
+            result.failfast = self.failfast
+            result.tb_locals = self.tb_locals
+        result.startTestRun()
+        try:
+            test(result)
+        finally:
+            result.stopTestRun()
+        return result
+
+    def list(self, test, loader=None):
+        "List the test."
+        result, errors = self._list(test)
+        if loader is not None:
+            errors = loader.errors
+        if errors:
+            failed_descr = '\n'.join(errors).encode('utf8')
+            result.status(file_name="import errors", runnable=False,
+                          file_bytes=failed_descr,
+                          mime_type="text/plain;charset=utf8")
+            sys.exit(2)
+
+    def _list(self, test):
+        test_ids, errors = program.list_test(test)
+        try:
+            fileno = self.stream.fileno()
+        except Exception:
+            fileno = None
+        if fileno is not None:
+            stream = os.fdopen(fileno, 'wb', 0)
+        else:
+            stream = self.stream
+        result = StreamResultToBytes(stream)
+        for test_id in test_ids:
+            result.status(test_id=test_id, test_status='exists')
+        return result, errors
+
+
+class SubunitTestProgram(program.TestProgram):
+
+    USAGE = program.USAGE_AS_MAIN
+
+    def usageExit(self, msg=None):
+        if msg:
+            print(msg)
+        usage = {'progName': self.progName, 'catchbreak': '', 'failfast': '',
+                 'buffer': ''}
+        if self.failfast is not False:
+            usage['failfast'] = program.FAILFAST
+        if self.catchbreak is not False:
+            usage['catchbreak'] = program.CATCHBREAK
+        if self.buffer is not False:
+            usage['buffer'] = program.BUFFEROUTPUT
+        usage_text = self.USAGE % usage
+        usage_lines = usage_text.split('\n')
+        usage_lines.insert(2, "Run a test suite with a subunit reporter.")
+        usage_lines.insert(3, "")
+        print('\n'.join(usage_lines))
+        sys.exit(2)
+
+
+def main():
+    runner = SubunitTestRunner
+    if sys.version_info[0] >= 3:
+        SubunitTestProgram(
+            module=None, argv=sys.argv,
+            testRunner=partial(runner, stdout=sys.stdout),
+            exit=False)
+    else:
+        from testtools import run as testtools_run
+        testtools_run.TestProgram(module=None, argv=sys.argv,
+                                  testRunner=runner,
+                                  stdout=sys.stdout, exit=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -25,7 +25,8 @@ from stestr.subunit_runner import program
 
 
 class SubunitTestRunner(object):
-    def __init__(self, failfast=False, tb_locals=False, stdout=sys.stdout):
+    def __init__(self, failfast=False, stream=None, tb_locals=False,
+                 stdout=None):
         """Create a Test Runner.
 
         :param failfast: Stop running tests at the first failure.
@@ -36,7 +37,7 @@ class SubunitTestRunner(object):
         precedence.
         """
         self.failfast = failfast
-        self.stream = stdout
+        self.stream = stream or stdout or sys.stdout
         self.tb_locals = tb_locals
 
     def run(self, test):

--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -25,22 +25,18 @@ from stestr.subunit_runner import program
 
 
 class SubunitTestRunner(object):
-    def __init__(self, verbosity=None, failfast=None, buffer=None,
-                 stream=None, stdout=None, tb_locals=False):
+    def __init__(self, failfast=False, tb_locals=False, stdout=sys.stdout):
         """Create a Test Runner.
 
-        :param verbosity: Ignored.
         :param failfast: Stop running tests at the first failure.
-        :param buffer: Ignored.
-        :param stream: Upstream unittest stream parameter.
-        :param stdout: Testtools stream parameter.
-        :param tb_locals: Testtools traceback in locals parameter.
+        :param stdout: Output stream parameter, defaults to sys.stdout
+        :param tb_locals: If set true local variables will be shown
 
         Either stream or stdout can be supplied, and stream will take
         precedence.
         """
         self.failfast = failfast
-        self.stream = stream or stdout or sys.stdout
+        self.stream = stdout
         self.tb_locals = tb_locals
 
     def run(self, test):
@@ -86,36 +82,12 @@ class SubunitTestRunner(object):
         return result, errors
 
 
-class SubunitTestProgram(program.TestProgram):
-
-    USAGE = program.USAGE_AS_MAIN
-
-    def usageExit(self, msg=None):
-        if msg:
-            print(msg)
-        usage = {'progName': self.progName, 'catchbreak': '', 'failfast': '',
-                 'buffer': ''}
-        if self.failfast is not False:
-            usage['failfast'] = program.FAILFAST
-        if self.catchbreak is not False:
-            usage['catchbreak'] = program.CATCHBREAK
-        if self.buffer is not False:
-            usage['buffer'] = program.BUFFEROUTPUT
-        usage_text = self.USAGE % usage
-        usage_lines = usage_text.split('\n')
-        usage_lines.insert(2, "Run a test suite with a subunit reporter.")
-        usage_lines.insert(3, "")
-        print('\n'.join(usage_lines))
-        sys.exit(2)
-
-
 def main():
     runner = SubunitTestRunner
     if sys.version_info[0] >= 3:
-        SubunitTestProgram(
+        program.TestProgram(
             module=None, argv=sys.argv,
-            testRunner=partial(runner, stdout=sys.stdout),
-            exit=False)
+            testRunner=partial(runner, stdout=sys.stdout))
     else:
         from testtools import run as testtools_run
         testtools_run.TestProgram(module=None, argv=sys.argv,

--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -25,8 +25,7 @@ from stestr.subunit_runner import program
 
 
 class SubunitTestRunner(object):
-    def __init__(self, failfast=False, stream=None, tb_locals=False,
-                 stdout=None):
+    def __init__(self, failfast=False, tb_locals=False, stdout=sys.stdout):
         """Create a Test Runner.
 
         :param failfast: Stop running tests at the first failure.
@@ -37,7 +36,7 @@ class SubunitTestRunner(object):
         precedence.
         """
         self.failfast = failfast
-        self.stream = stream or stdout or sys.stdout
+        self.stream = stdout
         self.tb_locals = tb_locals
 
     def run(self, test):

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -49,7 +49,7 @@ class TestTestrConf(base.TestCase):
         self.assertEqual(mock_TestProcessorFixture.return_value, fixture)
         mock_get_repo_open.assert_called_once_with('file',
                                                    None)
-        command = '%s -m subunit.run discover -t "%s" "%s" ' \
+        command = '%s -m stestr.subunit_runner.run discover -t "%s" "%s" ' \
                   '$LISTOPT $IDOPTION' % (expected_python, 'fake_top_dir',
                                           'fake_test_path')
         # Ensure TestProcessorFixture is created with defaults except for where


### PR DESCRIPTION
Right now stestr doesn't actually own it's own test runner. It leverages
the subunit.run test runner, subunit.run in turn inherets from
testtools.run, which inherets from unittest2. The usage of unittest2
causes all sorts of problems when running non-testtools or non-unittest2
test suites, because of mismatches between stdlib unittest and unittest2.
To address this problem this commit creates a new test runner for stestr
that will emit subunit which is the actual only hard requirement for the
internal test runner used. This new test runner is more or less identical
to subunit.run, but instead of inheriting from testtools it uses stdlib
unittest directly.
    
Python 2.7's stdlib unittest's test runner is much older and it was
changed significantly for python 3. So building a custom test runner
based on python 2's unittest would basically requiring maintaining a
completely separate copy of python 3's unittest runner in tree and then
building the subunit runner off of that, which is essentially what
unittest2 is anyway. Since python 2 support is deprecated anyway and
will be going away soon this commit just maintains the current status
quo of basing it off testtools for python 2.

Most of the code for the custom runner and the TestProgram class are
taken directly from subunit and testtools respectively.
    
Fixes #244 for the first stacktrace outlined there, which was caused by
the test runner (which was previously outside the scope of stestr).