### PR TITLE
Add license to package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ description-file =
 author = Matthew Treinish
 author-email = mtreinish@kortar.org
 home-page = http://stestr.readthedocs.io/en/latest/
+license = Apache-2.0
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators


### PR DESCRIPTION
This commit fixes an oversight in the package metadata for stestr. We
were missing an explicit license field [1] in the package metadata. This
would lead to pip showing the license as unknown when inspecting the
stestr package.

[1] https://packaging.python.org/specifications/core-metadata/#license