### PR TITLE
Use StringIO instead of tempfile

### DIFF
--- a/stestr/output.py
+++ b/stestr/output.py
@@ -75,7 +75,7 @@ def output_tests(tests, output=sys.stdout):
 
     for test in tests:
         id_str = test.id()
-        output.write(id_str)
+        output.write(six.text_type(id_str))
         output.write(six.text_type('\n'))
 
 
@@ -139,16 +139,16 @@ def output_summary(successful, tests, tests_delta, time, time_delta, values,
 
 
 def output_stream(stream, output=sys.stdout):
-        _binary_stdout = subunit.make_stream_binary(output)
+    _binary_stdout = subunit.make_stream_binary(output)
+    contents = stream.read(65536)
+    assert type(contents) is bytes, \
+        "Bad stream contents %r" % type(contents)
+    # If there are unflushed bytes in the text wrapper, we need to sync..
+    output.flush()
+    while contents:
+        _binary_stdout.write(contents)
         contents = stream.read(65536)
-        assert type(contents) is bytes, \
-            "Bad stream contents %r" % type(contents)
-        # If there are unflushed bytes in the text wrapper, we need to sync..
-        output.flush()
-        while contents:
-            _binary_stdout.write(contents)
-            contents = stream.read(65536)
-        _binary_stdout.flush()
+    _binary_stdout.flush()
 
 
 class ReturnCodeToSubunit(object):

--- a/stestr/tests/test_output.py
+++ b/stestr/tests/test_output.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import tempfile
+import io
 
 from stestr import output
 from stestr.tests import base
@@ -27,10 +27,9 @@ class TestOutput(base.TestCase):
             "--------  ----------  ------------------\n" \
             "1         0000000002  foo\n" \
             "bar       6           This is a content.\n"
-        with tempfile.TemporaryFile('w+t') as f:
+        with io.StringIO() as f:
             output.output_table(table, f)
-            f.seek(0)
-            actual = f.read()
+            actual = f.getvalue()
             self.assertEqual(expected, actual)
 
     def test_output_tests(self):
@@ -43,34 +42,31 @@ class TestOutput(base.TestCase):
 
         tests = [Test('a'), Test('b'), Test('foo')]
         expected = "a\nb\nfoo\n"
-        with tempfile.TemporaryFile('w+t') as f:
+        with io.StringIO() as f:
             output.output_tests(tests, f)
-            f.seek(0)
-            actual = f. read()
+            actual = f.getvalue()
             self.assertEqual(expected, actual)
 
     def test_output_summary_passed(self):
         expected = 'Ran 10 (+5) tests in 1.100s (+0.100s)\n' \
             'PASSED (id=99 (+1), id=100 (+2))\n'
-        with tempfile.TemporaryFile('w+t') as f:
+        with io.StringIO() as f:
             output.output_summary(
                 successful=True, tests=10, tests_delta=5,
                 time=1.1, time_delta=0.1,
                 values=[('id', 99, 1), ('id', '100', 2)],
                 output=f)
-            f.seek(0)
-            actual = f.read()
+            actual = f.getvalue()
             self.assertEqual(expected, actual)
 
     def test_output_summary_failed(self):
         expected = 'Ran 10 (+5) tests in 1.100s (+0.100s)\n' \
             'FAILED (id=99 (+1), id=100 (+2))\n'
-        with tempfile.TemporaryFile('w+t') as f:
+        with io.StringIO() as f:
             output.output_summary(
                 successful=False, tests=10, tests_delta=5,
                 time=1.1, time_delta=0.1,
                 values=[('id', 99, 1), ('id', '100', 2)],
                 output=f)
-            f.seek(0)
-            actual = f.read()
+            actual = f.getvalue()
             self.assertEqual(expected, actual)


### PR DESCRIPTION
This commit makes unit tests in test_output.py use io.StringIO instead
of tempfile. It can reduce the code (no need seek(0)). And this commit
also fixes inconsistent code in output.py::output_tests() because it
caused an error with StringIO and it should be the same with the later
one.
The last thing is fixing the indentation in output_stream() which was
just weird.