### PR TITLE
Add linux azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,3 +60,28 @@ jobs:
     displayName: 'Install dependencies'
   - script: tox -e py
     displayName: 'Run Tox'
+
+- job: 'Linux_Tests'
+  pool: {vmImage: 'ubuntu-16.04'}
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -U tox
+    displayName: 'Install dependencies'
+  - script: tox -e py
+    displayName: 'Run Tox'


### PR DESCRIPTION
This commit adds a linux (Ubuntu 16.04) testing job strategy to the
azure pipelines. This commit doesn't remove the current travis jobs
because it still works well and we should look at its stability of the
azure one. So, the next step would be removing the duplicated job
definition and implementing coveralls execution in the azure-pipelines.