### PR TITLE
Handle NoneType timestamps in subunit results

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -271,10 +271,11 @@ def _load_case(inserter, repo, case, subunit_out, pretty_out,
         start_times = []
         stop_times = []
         for worker in subunit_trace.RESULTS:
-            start_times += [
-                x['timestamps'][0] for x in subunit_trace.RESULTS[worker]]
-            stop_times += [
-                x['timestamps'][1] for x in subunit_trace.RESULTS[worker]]
+            for test in subunit_trace.RESULTS[worker]:
+                if not test['timestamps'][0] or not test['timestamps'][1]:
+                    continue
+                start_times.append(test['timestamps'][0])
+                stop_times.append(test['timestamps'][1])
         if not start_times or not stop_times:
             sys.stderr.write("\nNo tests were successful during the run")
             return 1


### PR DESCRIPTION
For some reason there are cases when a Nonetype object gets set as a
timestamp for a subunit result. Then when we go to analyze the total
test run in stestr load for subunit-trace output the min() or max()
calls to figure out the total test run duration it will fail because
python can't compare a Nonetype and a datetime.datetime. This commit
addresses this by ignoring cases where the a None is inserted.