### PR TITLE
Only use stdlib based unittest runner for py >=3.5

### DIFF
--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -84,7 +84,7 @@ class SubunitTestRunner(object):
 
 def main():
     runner = SubunitTestRunner
-    if sys.version_info[0] >= 3:
+    if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
         program.TestProgram(
             module=None, argv=sys.argv,
             testRunner=partial(runner, stdout=sys.stdout))


### PR DESCRIPTION
The stdlib python test runner introduced in #256 was written assuming a
python stdlib from python 3.5 or newer. Since we only officially support
running on python 3.5 or newer when we added the logic to switch between
the stdlib runner and the old testtools based runner we just said
python >=3.0.0. However, despite our official support status for
python >2.7,<3.5 there are still users out there running stestr on these python
versions. The new test runner will not work for those users because
unittest in stdlib changed in python 3.5 (as an aside this is the same
issue I've been hitting in my attempts to get unittest2 removed from
testtools). To address this problem a simple fix is to just change the
if statement to be a bit more explicit and only use the new runner for
python 3.5 or newer. This way stestr is more explicit about where the
newer runner actually works and this should hopefully unbreak any users
out there still using python 3.0 to 3.4.

Fixes #264