### PR TITLE
Remove abbreviated option for stestr run --random

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -121,7 +121,7 @@ class Run(command.Command):
                             help="Takes in a single test to bypasses test "
                             "discover and just execute the test specified. A "
                             "file may be used in place of a test name.")
-        parser.add_argument('--random', '-r', action="store_true",
+        parser.add_argument('--random', action="store_true",
                             default=False,
                             help="Randomize the test order after they are "
                             "partitioned into separate workers")


### PR DESCRIPTION
This commit removes '-r' option which is an abbreviation for '--random'.
The option is conflicted with --repo-type/-r option and it doesn't work
properly. So, we can remove this now.

Fixes: #136