### PR TITLE
Remove stray reference to removed short form of --random

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -430,7 +430,7 @@ tests will be partitioned across those workers with the normal scheduler. This
 includes respecting the other scheduler options, like ``group_regex`` or
 ``--random``.
 
-There is also an option on ``stestr run``, ``--random``/``-r`` to randomize the
+There is also an option on ``stestr run``, ``--random`` to randomize the
 order of tests as they are passed to the workers. This is useful in certain
 use cases, especially when you want to test isolation between test cases.
 


### PR DESCRIPTION
In #267 we removed the short form for --random (-r) since this was
duplicated with --repo-type's short form (also -r). Since the 2.0.0
release which introduced cliff usage the -r option only worked for repo
type and would always error when trying to use it like --random. However
that PR neglected to remove a reference to the short form of --random in
the stestr manual. This commit corrects the oversight and removes the
reference.