### PR TITLE
Stop encoding attachments text

### DIFF
--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -123,7 +123,6 @@ def print_attachments(stream, test, all_channels=False):
             # indent attachment lines 4 spaces to make them visually
             # offset
             for line in detail.as_text().split('\n'):
-                line = line.encode('utf8')
                 stream.write("    %s\n" % line)
 
 


### PR DESCRIPTION
The attachments text in print_attachments() for the subunit_trace output
was encoding the text as utf8 for some reason which made the text of
type bytes. When bytes objects are printed by python 3 they're marked as
bytes by wrapping the text in b''. However this encode is unecessary (and
would likely break unicode characters) as just writing the str literals
for each line to the output stream works just fine. The encode() call was
added in [1] before stestr was started, and was just added for the case
of using LANG=C to set their locale to ASCII C. This was also before the
adoption of PEP 538 [2] which makes python use unicode even if LANG=C is
set. So removing the encode for supporting that use case shouldn't
matter anymore.

Fixes #243

[1] https://review.opendev.org/#/c/229527/
[2] https://www.python.org/dev/peps/pep-0538