### PR TITLE
Handle empty .stestr directory to initialize

### DIFF
--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -12,6 +12,7 @@
 
 """Initialise a new repository."""
 
+import errno
 import sys
 
 from cliff import command
@@ -47,7 +48,7 @@ def init(repo_type='file', repo_url=None, stdout=sys.stdout):
     try:
         util.get_repo_initialise(repo_type, repo_url)
     except OSError as e:
-        if e.errno != 17:
+        if e.errno != errno.EEXIST:
             raise
         repo_path = repo_url or './stestr'
         stdout.write('The specified repository directory %s already exists. '

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -12,6 +12,7 @@
 
 """Run a projects tests and load them into stestr."""
 
+import errno
 import os
 import subprocess
 import sys
@@ -354,7 +355,17 @@ def run_command(config='.stestr.conf', repo_type='file',
                    "--test-path ")
             stdout.write(msg)
             exit(1)
-        repo = util.get_repo_initialise(repo_type, repo_url)
+        try:
+            repo = util.get_repo_initialise(repo_type, repo_url)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+            repo_path = repo_url or './stestr'
+            stdout.write('The specified repository directory %s already '
+                         'exists. Please check if the repository already '
+                         'exists or select a different path\n' % repo_path)
+            return 1
+
     combine_id = None
     concurrency = _to_int(concurrency)
 

--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -40,7 +40,14 @@ class RepositoryFactory(repository.AbstractRepositoryFactory):
     def initialise(klass, url):
         """Create a repository at url/path."""
         base = os.path.join(os.path.expanduser(url), '.stestr')
-        os.mkdir(base)
+        try:
+            os.mkdir(base)
+        except OSError as e:
+            if e.errno == errno.EEXIST and not os.listdir(base):
+                # It shouldn't be harmful initializing an empty dir
+                pass
+            else:
+                raise
         with open(os.path.join(base, 'format'), 'wt') as stream:
             stream.write('1\n')
         result = Repository(base)


### PR DESCRIPTION
This commit make an empty .stestr directory initialize if it exists.
Originally, we make it errors or weird errors occur when there is.
However, an empty .stestr directory can be initialized and no error
shouldn't be occurred with it.

Fixes: #266