### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36
     - os: linux
+      python: 3.8
+      env: TOXENV=py38
+    - os: linux
       dist: xenial
       python: 3.7
       env: TOXENV=py37

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -48,6 +50,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,6 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-      Python38:
-        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -50,8 +48,6 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-      Python38:
-        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
 project_urls =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py37,py36,py35,py34,py27,pep8
+envlist = py38,py37,py36,py35,py34,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Now that python 3.8 has been released we should add support for running
under it to stestr. This commit adds the required CI jobs to verify that
everything runs on 3.8 and also updates the package metadata to indicate
we support running on 3.8.