### PR TITLE
Clean up DeprecationWarnings under python36

### DIFF
--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -36,7 +36,7 @@ class StestrCLI(app.App):
 
     def prepare_to_run_command(self, cmd):
         self.LOG.debug('prepare_to_run_command %s', cmd.__class__.__name__)
-        group_regex = '([^\.]*\.)*' \
+        group_regex = r'([^\.]*\.)*' \
             if cmd.app_args.parallel_class else cmd.app_args.group_regex
         cmd.app_args.group_regex = group_regex
 

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -144,11 +144,11 @@ class TestrConf(object):
         # If the command contains $IDOPTION read that command from config
         # Use a group regex if one is defined
         if parallel_class:
-            group_regex = '([^\.]*\.)*'
+            group_regex = r'([^\.]*\.)*'
         if not group_regex \
                 and self.parser.has_option('DEFAULT', 'parallel_class') \
                 and self.parser.getboolean('DEFAULT', 'parallel_class'):
-            group_regex = '([^\.]*\.)*'
+            group_regex = r'([^\.]*\.)*'
         if not group_regex and self.parser.has_option('DEFAULT',
                                                       'group_regex'):
             group_regex = self.parser.get('DEFAULT', 'group_regex')

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -104,7 +104,7 @@ class TestProcessorFixture(fixtures.Fixture):
 
     def setUp(self):
         super(TestProcessorFixture, self).setUp()
-        variable_regex = '\$(IDOPTION|IDFILE|IDLIST|LISTOPT)'
+        variable_regex = r'\$(IDOPTION|IDFILE|IDLIST|LISTOPT)'
         variables = {}
         list_variables = {'LISTOPT': self.listopt}
         cmd = self.template


### PR DESCRIPTION
/vpp/.tox/py36/lib/python3.6/site-packages/stestr/cli.py:39: DeprecationWarning: invalid escape sequence \.
  group_regex = '([^\.]*\.)*' \
/vpp/.tox/py36/lib/python3.6/site-packages/stestr/config_file.py:130: DeprecationWarning: invalid escape sequence \.
  group_regex = '([^\.]*\.)*'
/vpp/.tox/py36/lib/python3.6/site-packages/stestr/config_file.py:134: DeprecationWarning: invalid escape sequence \.
  group_regex = '([^\.]*\.)*'
/vpp/.tox/py36/lib/python3.6/site-packages/stestr/test_processor.py:107: DeprecationWarning: invalid escape sequence \$
  variable_regex = '\$(IDOPTION|IDFILE|IDLIST|LISTOPT)'