### PR TITLE
Add python 3.8 macOS and windows ci jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -48,6 +50,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
   steps:
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
Python 3.8 support was added to stestr in #277, but at that time the
azure pipelines ci environment did not have support for python 3.8 in
the images. So CI for python 3.8 on Windows and macOS was not added at
that time because we use azure pipelines for that. However, python 3.8
has been added to the azure pipelines images now so this commit adds the
missing CI jobs to verify that everything works as expected on python
3.8 for windows and macOS users.

Fixes #280