### PR TITLE
Treat bytes and strings differently

### DIFF
--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -65,6 +65,10 @@ class Last(command.Command):
                             dest='all_attachments',
                             help='If set print all text attachment contents on'
                             ' a successful test execution')
+        parser.add_argument('--show-binary-attachments', action='store_true',
+                            dest='show_binary_attachments',
+                            help='If set, show non-text attachments. This is '
+                            'generally only useful for debug purposes.')
         return parser
 
     def take_action(self, parsed_args):
@@ -108,12 +112,13 @@ class Last(command.Command):
                     repo_url=self.app_args.repo_url,
                     subunit_out=args.subunit, pretty_out=pretty_out,
                     color=color, suppress_attachments=suppress_attachments,
-                    all_attachments=all_attachments)
+                    all_attachments=all_attachments,
+                    show_binary_attachments=args.show_binary_attachments)
 
 
 def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
          color=False, stdout=sys.stdout, suppress_attachments=False,
-         all_attachments=False):
+         all_attachments=False, show_binary_attachments=False):
     """Show the last run loaded into a a repository
 
     This function will print the results from the last run in the repository
@@ -137,6 +142,8 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
         will not print attachments on successful test execution.
     :param bool all_attachments: When set true subunit_trace will print all
         text attachments on successful test execution.
+    :param bool show_binary_attachments: When set to true, subunit_trace will
+        print binary attachments in addition to text attachments.
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -182,10 +189,11 @@ def last(repo_type='file', repo_url=None, subunit_out=False, pretty_out=True,
         failed = not results.wasSuccessful(summary)
     else:
         stream = latest_run.get_subunit_stream()
-        failed = subunit_trace.trace(stream, stdout, post_fails=True,
-                                     color=color,
-                                     suppress_attachments=suppress_attachments,
-                                     all_attachments=all_attachments)
+        failed = subunit_trace.trace(
+            stream, stdout, post_fails=True, color=color,
+            suppress_attachments=suppress_attachments,
+            all_attachments=all_attachments,
+            show_binary_attachments=show_binary_attachments)
     if failed:
         return 1
     else:

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -86,6 +86,10 @@ class Load(command.Command):
                             dest='all_attachments',
                             help='If set print all text attachment contents on'
                             ' a successful test execution')
+        parser.add_argument('--show-binary-attachments', action='store_true',
+                            dest='show_binary_attachments',
+                            help='If set, show non-text attachments. This is '
+                            'generally only useful for debug purposes.')
         return parser
 
     def take_action(self, parsed_args):
@@ -134,14 +138,15 @@ class Load(command.Command):
              pretty_out=pretty_out, color=color,
              stdout=stdout, abbreviate=abbreviate,
              suppress_attachments=suppress_attachments, serial=True,
-             all_attachments=all_attachments)
+             all_attachments=all_attachments,
+             show_binary_attachments=args.show_binary_attachments)
 
 
 def load(force_init=False, in_streams=None,
          partial=False, subunit_out=False, repo_type='file', repo_url=None,
          run_id=None, streams=None, pretty_out=False, color=False,
          stdout=sys.stdout, abbreviate=False, suppress_attachments=False,
-         serial=False, all_attachments=False):
+         serial=False, all_attachments=False, show_binary_attachments=False):
     """Load subunit streams into a repository
 
     This function will load subunit streams into the repository. It will
@@ -172,6 +177,8 @@ def load(force_init=False, in_streams=None,
         will not print attachments on successful test execution.
     :param bool all_attachments: When set true subunit_trace will print all
         text attachments on successful test execution.
+    :param bool show_binary_attachments: When set to true, subunit_trace will
+        print binary attachments in addition to text attachments.
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -233,7 +240,8 @@ def load(force_init=False, in_streams=None,
                 stream, non_subunit_name='stdout')
             result = _load_case(inserter, repo, case, subunit_out, pretty_out,
                                 color, stdout, abbreviate,
-                                suppress_attachments, all_attachments)
+                                suppress_attachments, all_attachments,
+                                show_binary_attachments)
             if result or retval:
                 retval = 1
             else:
@@ -242,14 +250,14 @@ def load(force_init=False, in_streams=None,
         case = testtools.ConcurrentStreamTestSuite(make_tests)
         retval = _load_case(inserter, repo, case, subunit_out, pretty_out,
                             color, stdout, abbreviate, suppress_attachments,
-                            all_attachments)
+                            all_attachments, show_binary_attachments)
 
     return retval
 
 
 def _load_case(inserter, repo, case, subunit_out, pretty_out,
                color, stdout, abbreviate, suppress_attachments,
-               all_attachments):
+               all_attachments, show_binary_attachments):
     if subunit_out:
         output_result, summary_result = output.make_result(inserter.get_id,
                                                            output=stdout)
@@ -258,7 +266,8 @@ def _load_case(inserter, repo, case, subunit_out, pretty_out,
             functools.partial(subunit_trace.show_outcome, stdout,
                               enable_color=color, abbreviate=abbreviate,
                               suppress_attachments=suppress_attachments,
-                              all_attachments=all_attachments))
+                              all_attachments=all_attachments,
+                              show_binary_attachments=show_binary_attachments))
         summary_result = testtools.StreamSummary()
         output_result = testtools.CopyStreamResult([outcomes, summary_result])
         output_result = testtools.StreamResultRouter(output_result)

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -168,6 +168,10 @@ class Run(command.Command):
                             dest='all_attachments',
                             help='If set print all text attachment contents on'
                             ' a successful test execution')
+        parser.add_argument('--show-binary-attachments', action='store_true',
+                            dest='show_binary_attachments',
+                            help='If set, show non-text attachments. This is '
+                            'generally only useful for debug purposes.')
         return parser
 
     def take_action(self, parsed_args):
@@ -244,7 +248,9 @@ class Run(command.Command):
             filters=filters, pretty_out=pretty_out, color=color,
             stdout=stdout, abbreviate=abbreviate,
             suppress_attachments=suppress_attachments,
-            all_attachments=all_attachments, pdb=args.pdb)
+            all_attachments=all_attachments,
+            show_binary_attachments=args.show_binary_attachments,
+            pdb=args.pdb)
 
         # Always output slowest test info if requested, regardless of other
         # test run options
@@ -285,7 +291,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                 no_discover=False, random=False, combine=False, filters=None,
                 pretty_out=True, color=False, stdout=sys.stdout,
                 abbreviate=False, suppress_attachments=False,
-                all_attachments=False, pdb=False):
+                all_attachments=False, show_binary_attachments=True,
+                pdb=False):
     """Function to execute the run command
 
     This function implements the run command. It will run the tests specified
@@ -348,6 +355,8 @@ def run_command(config='.stestr.conf', repo_type='file',
         will not print attachments on successful test execution.
     :param bool all_attachments: When set true subunit_trace will print all
         text attachments on successful test execution.
+    :param bool show_binary_attachments: When set to true, subunit_trace will
+        print binary attachments in addition to text attachments.
     :param str pdb: Takes in a single test_id to bypasses test
         discover and just execute the test specified without launching any
         additional processes. A file name may be used in place of a test name.
@@ -430,7 +439,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                              pretty_out=pretty_out,
                              color=color, stdout=stdout, abbreviate=abbreviate,
                              suppress_attachments=suppress_attachments,
-                             all_attachments=all_attachments)
+                             all_attachments=all_attachments,
+                             show_binary_attachments=show_binary_attachments)
 
         if not until_failure:
             return run_tests()
@@ -475,7 +485,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                          pretty_out=pretty_out,
                          color=color, stdout=stdout, abbreviate=abbreviate,
                          suppress_attachments=suppress_attachments,
-                         all_attachments=all_attachments)
+                         all_attachments=all_attachments,
+                         show_binary_attachments=show_binary_attachments)
 
     if failing or analyze_isolation:
         ids = _find_failing(repo)
@@ -525,7 +536,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                     repo_type=repo_type, repo_url=repo_url,
                     pretty_out=pretty_out, color=color, abbreviate=abbreviate,
                     stdout=stdout, suppress_attachments=suppress_attachments,
-                    all_attachments=all_attachments)
+                    all_attachments=all_attachments,
+                    show_binary_attachments=show_binary_attachments)
                 if run_result > result:
                     result = run_result
             return result
@@ -540,7 +552,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                               stdout=stdout,
                               abbreviate=abbreviate,
                               suppress_attachments=suppress_attachments,
-                              all_attachments=all_attachments)
+                              all_attachments=all_attachments,
+                              show_binary_attachments=show_binary_attachments)
     else:
         # Where do we source data about the cause of conflicts.
         latest_run = repo.get_latest_run()
@@ -585,7 +598,7 @@ def _run_tests(cmd, until_failure,
                subunit_out=False, combine_id=None, repo_type='file',
                repo_url=None, pretty_out=True, color=False, stdout=sys.stdout,
                abbreviate=False, suppress_attachments=False,
-               all_attachments=False):
+               all_attachments=False, show_binary_attachments=False):
     """Run the tests cmd was parameterised with."""
     cmd.setUp()
     try:
@@ -603,7 +616,8 @@ def _run_tests(cmd, until_failure,
                              pretty_out=pretty_out, color=color, stdout=stdout,
                              abbreviate=abbreviate,
                              suppress_attachments=suppress_attachments,
-                             all_attachments=all_attachments)
+                             all_attachments=all_attachments,
+                             show_binary_attachments=show_binary_attachments)
 
         if not until_failure:
             return run_tests()


### PR DESCRIPTION
The 'as_text()' helper function for the 'testtools.content.Content' class fails if it attempts to decode a binary result. The fact that we have a binary result is a bug in itself but we need to log what we're getting to help debug this. Start ignoring these by default but add an option, '--show-binary-attachments', to allow us to emit these if we want it for debug purposes.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Related-bug: #1813147