### PR TITLE
Remove python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
       env: TOXENV=pep8
     - python: "3.6"
       env: TOXENV=docs
-    - python: "2.7"
-      env: TOXENV=py27
     - if: tag IS present
       python: "3.6"
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,6 @@ jobs:
   pool: {vmImage: 'vs2017-win2016'}
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
       Python35:
         python.version: '3.5'
       Python36:
@@ -42,8 +40,6 @@ jobs:
   pool: {vmImage: 'macOS-10.14'}
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
       Python35:
         python.version: '3.5'
       Python36:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.3.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD
-six>=1.10.0 # MIT
 testtools>=2.2.0 # MIT
 PyYAML>=3.10.0 # MIT
 voluptuous>=0.8.9 # BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,6 @@ stestr.cm =
 sql =
     subunit2sql>=1.8.0
 
-[bdist_wheel]
-universal=1
-
 [build_sphinx]
 source-dir = doc/source
 build-dir = doc/build

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
@@ -27,7 +25,7 @@ project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-requires-python = >=2.7
+requires-python = >=3.5
 
 [files]
 packages =

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -108,12 +108,6 @@ class StestrCLI(app.App):
 
 
 def main(argv=sys.argv[1:]):
-    if sys.version_info[:2] == (2, 7):
-        msg = (
-            "Python 2.7 will reach the end of its life on January 1st, 2020. "
-            "Support for using python 2.7 with stestr will be removed in the "
-            "3.0.0 release in early 2020")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     cli = StestrCLI()
     return cli.run(argv)
 

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import sys
-import warnings
 
 from cliff import app
 from cliff import commandmanager

--- a/stestr/colorizer.py
+++ b/stestr/colorizer.py
@@ -82,7 +82,7 @@ class AnsiColorizer(object):
         @param color: A string label for a color. e.g. 'red', 'white'.
         """
         color = self._colors[color]
-        self.stream.write('\x1b[%s;1m%s\x1b[0m' % (color, text))
+        self.stream.write('\x1b[{};1m{}\x1b[0m'.format(color, text))
 
 
 class NullColorizer(object):

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -21,7 +21,6 @@ import sys
 import warnings
 
 from cliff import command
-import six
 import subunit
 import testtools
 
@@ -46,7 +45,7 @@ def _to_int(possible, default=0, out=sys.stderr):
         i = default
         msg = ('Unable to convert "%s" to an integer.  Using %d.\n' %
                (possible, default))
-        out.write(six.text_type(msg))
+        out.write(str(msg))
     return i
 
 
@@ -390,7 +389,7 @@ def run_command(config='.stestr.conf', repo_type='file',
         return 2
     if combine:
         latest_id = repo.latest_id()
-        combine_id = six.text_type(latest_id)
+        combine_id = str(latest_id)
     if no_discover and pdb:
         msg = ("--no-discover and --pdb are mutually exclusive options, "
                "only specify one at a time")

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -106,7 +106,7 @@ class TestrConf(object):
             test_path = self.parser.get('DEFAULT', 'test_path')
         elif not test_path:
             sys.exit("No test_path can be found in either the command line "
-                     "options nor in the specified config file {0}.  Please "
+                     "options nor in the specified config file {}.  Please "
                      "specify a test path either in the config file or via "
                      "the --test-path argument".format(self.config_file))
         if not top_dir and self.parser.has_option('DEFAULT', 'top_dir'):

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 
-from six.moves import configparser
+import configparser
 
 from stestr.repository import util
 from stestr import test_processor

--- a/stestr/output.py
+++ b/stestr/output.py
@@ -109,16 +109,16 @@ def output_summary(successful, tests, tests_delta, time, time_delta, values,
     summary = []
     a = summary.append
     if tests:
-        a("Ran %s" % (tests,))
+        a("Ran {}".format(tests))
         if tests_delta:
             a(" (%+d)" % (tests_delta,))
         a(" tests")
     if time:
         if not summary:
             a("Ran tests")
-        a(" in %0.3fs" % (time,))
+        a(" in {:0.3f}s".format(time))
         if time_delta:
-            a(" (%+0.3fs)" % (time_delta,))
+            a(" ({:+0.3f}s)".format(time_delta))
     if summary:
         a("\n")
     if successful:
@@ -129,7 +129,7 @@ def output_summary(successful, tests, tests_delta, time, time_delta, values,
         a(' (')
         values_strings = []
         for name, value, delta in values:
-            value_str = '%s=%s' % (name, value)
+            value_str = '{}={}'.format(name, value)
             if delta:
                 value_str += ' (%+d)' % (delta,)
             values_strings.append(value_str)
@@ -169,7 +169,7 @@ class ReturnCodeToSubunit(object):
         self.proc = process
         self.done = False
         self.source = self.proc.stdout
-        self.lastoutput = bytes(('\n').encode('utf8')[0])
+        self.lastoutput = bytes((b'\n')[0])
 
     def _append_return_code_as_test(self):
         if self.done is True:
@@ -177,7 +177,7 @@ class ReturnCodeToSubunit(object):
         self.source = io.BytesIO()
         returncode = self.proc.wait()
         if returncode != 0:
-            if self.lastoutput != bytes(('\n').encode('utf8')[0]):
+            if self.lastoutput != bytes((b'\n')[0]):
                 # Subunit V1 is line orientated, it has to start on a fresh
                 # line. V2 needs to start on any fresh utf8 character border
                 # - which is not guaranteed in an arbitrary stream endpoint, so

--- a/stestr/output.py
+++ b/stestr/output.py
@@ -12,7 +12,6 @@
 
 import sys
 
-import six
 import subunit
 import testtools
 
@@ -62,7 +61,7 @@ def output_table(table, output=sys.stdout):
         outputs.append('  ')
     for row in contents[1:]:
         show_row(row)
-    output.write(six.text_type('').join(outputs))
+    output.write(''.join(outputs))
 
 
 def output_tests(tests, output=sys.stdout):
@@ -75,8 +74,8 @@ def output_tests(tests, output=sys.stdout):
 
     for test in tests:
         id_str = test.id()
-        output.write(six.text_type(id_str))
-        output.write(six.text_type('\n'))
+        output.write(str(id_str))
+        output.write('\n')
 
 
 def make_result(get_id, output=sys.stdout):
@@ -135,7 +134,7 @@ def output_summary(successful, tests, tests_delta, time, time_delta, values,
             values_strings.append(value_str)
         a(', '.join(values_strings))
         a(')')
-    output.write(six.text_type(''.join(summary)) + six.text_type('\n'))
+    output.write(''.join(summary) + '\n')
 
 
 def output_stream(stream, output=sys.stdout):
@@ -169,20 +168,20 @@ class ReturnCodeToSubunit(object):
         self.proc = process
         self.done = False
         self.source = self.proc.stdout
-        self.lastoutput = six.binary_type(('\n').encode('utf8')[0])
+        self.lastoutput = bytes(('\n').encode('utf8')[0])
 
     def _append_return_code_as_test(self):
         if self.done is True:
             return
-        self.source = six.BytesIO()
+        self.source = io.BytesIO()
         returncode = self.proc.wait()
         if returncode != 0:
-            if self.lastoutput != six.binary_type(('\n').encode('utf8')[0]):
+            if self.lastoutput != bytes(('\n').encode('utf8')[0]):
                 # Subunit V1 is line orientated, it has to start on a fresh
                 # line. V2 needs to start on any fresh utf8 character border
                 # - which is not guaranteed in an arbitrary stream endpoint, so
                 # injecting a \n gives us such a guarantee.
-                self.source.write(six.binary_type('\n'))
+                self.source.write(bytes('\n'))
             stream = subunit.StreamResultToBytes(self.source)
             stream.status(test_id='process-returncode', test_status='fail',
                           file_name='traceback',
@@ -194,7 +193,7 @@ class ReturnCodeToSubunit(object):
 
     def read(self, count=-1):
         if count == 0:
-            return six.text_type('')
+            return ''
         result = self.source.read(count)
         if result:
             self.lastoutput = result[-1]

--- a/stestr/output.py
+++ b/stestr/output.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import io
 import sys
 
 import subunit

--- a/stestr/repository/sql.py
+++ b/stestr/repository/sql.py
@@ -20,7 +20,6 @@ import re
 import subprocess
 import sys
 
-import six
 import sqlalchemy
 from sqlalchemy import orm
 import subunit.v2
@@ -55,8 +54,8 @@ class RepositoryFactory(repository.AbstractRepositoryFactory):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         out, err = proc.communicate()
-        sys.stdout.write(six.text_type(out))
-        sys.stderr.write(six.text_type(err))
+        sys.stdout.write(str(out))
+        sys.stderr.write(str(err))
 
         return result
 

--- a/stestr/repository/sql.py
+++ b/stestr/repository/sql.py
@@ -254,7 +254,7 @@ class _SqlInserter(repository.AbstractTestRun):
         return db_test
 
     def _get_attrs(self, test_id):
-        attr_regex = re.compile('\[(.*)\]')
+        attr_regex = re.compile(r'\[(.*)\]')
         matches = attr_regex.search(test_id)
         attrs = None
         if matches:

--- a/stestr/results.py
+++ b/stestr/results.py
@@ -10,7 +10,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import six
 import subunit
 import testtools
 
@@ -98,10 +97,10 @@ class CLITestResult(testtools.StreamResult):
         test_tags = test_tags or ()
         tags = ' '.join(test_tags)
         if tags:
-            tags = six.text_type(('tags: %s\n' % tags))
-        return six.text_type(''.join([
+            tags = str(('tags: %s\n' % tags))
+        return str(''.join([
             self.sep1,
-            six.text_type('%s: %s\n' % (label, test.id())),
+            str('%s: %s\n' % (label, test.id())),
             tags,
             self.sep2,
             error_text,
@@ -114,7 +113,7 @@ class CLITestResult(testtools.StreamResult):
         test_tags = kwargs.get('test_tags')
         if test_status == 'fail':
             self.stream.write(
-                self._format_error(six.text_type('FAIL'),
+                self._format_error(str('FAIL'),
                                    *(self._summary.errors[-1]),
                                    test_tags=test_tags))
         if test_status not in self.filterable_states:

--- a/stestr/results.py
+++ b/stestr/results.py
@@ -90,17 +90,17 @@ class CLITestResult(testtools.StreamResult):
         self.stream = testtools.compat.unicode_output_stream(stream)
         self.sep1 = testtools.compat._u('=' * 70 + '\n')
         self.sep2 = testtools.compat._u('-' * 70 + '\n')
-        self.filterable_states = set(['success', 'uxsuccess', 'xfail', 'skip'])
+        self.filterable_states = {'success', 'uxsuccess', 'xfail', 'skip'}
         self.get_id = get_id
 
     def _format_error(self, label, test, error_text, test_tags=None):
         test_tags = test_tags or ()
         tags = ' '.join(test_tags)
         if tags:
-            tags = str(('tags: %s\n' % tags))
+            tags = str('tags: %s\n' % tags)
         return str(''.join([
             self.sep1,
-            str('%s: %s\n' % (label, test.id())),
+            str('{}: {}\n'.format(label, test.id())),
             tags,
             self.sep2,
             error_text,

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -102,11 +102,11 @@ def list_test(test):
     :return: A tuple of test ids that would run and error strings
         describing things that failed to import.
     """
-    unittest_import_strs = set([
+    unittest_import_strs = {
         'unittest2.loader.ModuleImportFailure.',
         'unittest.loader.ModuleImportFailure.',
         'discover.ModuleImportFailure.'
-        ])
+        }
     test_ids = []
     errors = []
     for test in iterate_tests(test):
@@ -178,7 +178,7 @@ class TestProgram(unittest.TestProgram):
                 lines = source.readlines()
             finally:
                 source.close()
-            test_ids = set(line.strip().decode('utf-8') for line in lines)
+            test_ids = {line.strip().decode('utf-8') for line in lines}
             self.test = filter_by_ids(self.test, test_ids)
         # XXX: Local edit (see http://bugs.python.org/issue22860)
         if not self.listtests:

--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -84,15 +84,9 @@ class SubunitTestRunner(object):
 
 def main():
     runner = SubunitTestRunner
-    if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
-        program.TestProgram(
-            module=None, argv=sys.argv,
-            testRunner=partial(runner, stdout=sys.stdout))
-    else:
-        from testtools import run as testtools_run
-        testtools_run.TestProgram(module=None, argv=sys.argv,
-                                  testRunner=runner,
-                                  stdout=sys.stdout, exit=False)
+    program.TestProgram(
+        module=None, argv=sys.argv,
+        testRunner=partial(runner, stdout=sys.stdout))
 
 
 if __name__ == '__main__':

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -119,7 +119,7 @@ def print_attachments(stream, test, all_channels=False):
             detail.content_type.type = 'text'
         if (all_channels or name in channels) and detail.as_text():
             title = "Captured %s:" % name
-            stream.write("\n%s\n%s\n" % (title, ('~' * len(title))))
+            stream.write("\n{}\n{}\n".format(title, ('~' * len(title))))
             # indent attachment lines 4 spaces to make them visually
             # offset
             for line in detail.as_text().split('\n'):
@@ -184,7 +184,7 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
         if abbreviate:
             color.write('F', 'red')
         else:
-            stream.write('{%s} %s [%s] ... ' % (
+            stream.write('{{{}}} {} [{}] ... '.format(
                 worker, name, duration))
             color.write('FAILED', 'red')
             stream.write('\n')
@@ -195,7 +195,7 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
             if abbreviate:
                 color.write('.', 'green')
             else:
-                out_string = '{%s} %s [%s' % (worker, name, duration)
+                out_string = '{{{}}} {} [{}'.format(worker, name, duration)
                 perc_diff = find_test_run_time_diff(test['id'], duration)
                 if enable_diff:
                     if perc_diff and abs(perc_diff) >= abs(float(threshold)):
@@ -218,7 +218,7 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
                 reason = test['details'].get('reason', '')
                 if reason:
                     reason = ': ' + reason.as_text()
-                stream.write('{%s} %s ... ' % (
+                stream.write('{{{}}} {} ... '.format(
                     worker, name))
                 color.write('SKIPPED', 'blue')
                 stream.write('%s' % (reason))
@@ -227,7 +227,7 @@ def show_outcome(stream, test, print_failures=False, failonly=False,
             if abbreviate:
                 stream.write('%s' % test['status'][0])
             else:
-                stream.write('{%s} %s [%s] ... %s\n' % (
+                stream.write('{{{}}} {} [{}] ... {}\n'.format(
                     worker, name, duration, test['status']))
                 if not print_failures:
                     print_attachments(stream, test, all_channels=True)
@@ -289,7 +289,7 @@ def worker_stats(worker):
 
 def print_summary(stream, elapsed_time):
     stream.write("\n======\nTotals\n======\n")
-    stream.write("Ran: %s tests in %.4f sec.\n" % (
+    stream.write("Ran: {} tests in {:.4f} sec.\n".format(
         count_tests('status', '.*'), total_seconds(elapsed_time)))
     stream.write(" - Passed: %s\n" % count_tests('status', '^success$'))
     stream.write(" - Skipped: %s\n" % count_tests('status', '^skip$'))
@@ -309,7 +309,7 @@ def print_summary(stream, elapsed_time):
                     " - WARNING: missing Worker %s!\n" % w)
             else:
                 num, time = worker_stats(w)
-                out_str = " - Worker %s (%s tests) => %s" % (w, num, time)
+                out_str = " - Worker {} ({} tests) => {}".format(w, num, time)
                 if time.isdigit():
                     out_str += 's'
                 out_str += '\n'

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import io
 import os
 import re
 import signal
@@ -18,7 +19,6 @@ import sys
 import tempfile
 
 import fixtures
-import six
 from subunit import v2
 
 from stestr import results
@@ -205,21 +205,15 @@ class TestProcessorFixture(fixtures.Fixture):
             sys.stdout.write("\n=========================\n"
                              "Failures during discovery"
                              "\n=========================\n")
-            new_out = six.BytesIO()
+            new_out = io.BytesIO()
             v2.ByteStreamToStreamResult(
-                six.BytesIO(out), 'stdout').run(
+                io.BytesIO(out), 'stdout').run(
                     results.CatFiles(new_out))
             out = new_out.getvalue()
             if out:
-                if six.PY3:
-                    sys.stdout.write(out.decode('utf8'))
-                else:
-                    sys.stdout.write(out)
+                sys.stdout.write(out.decode('utf8'))
             if err:
-                if six.PY3:
-                    sys.stderr.write(err.decode('utf8'))
-                else:
-                    sys.stderr.write(err)
+                sys.stderr.write(err.decode('utf8'))
             sys.stdout.write("\n" + "=" * 80 + "\n"
                              "The above traceback was encountered during "
                              "test discovery which imports all the found test"

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -217,7 +217,7 @@ class TestProcessorFixture(fixtures.Fixture):
                     sys.stdout.write(out)
             if err:
                 if six.PY3:
-                    sys.stdout.write(out.decode('utf8'))
+                    sys.stderr.write(err.decode('utf8'))
                 else:
                     sys.stderr.write(err)
             sys.stdout.write("\n" + "=" * 80 + "\n"

--- a/stestr/testlist.py
+++ b/stestr/testlist.py
@@ -12,7 +12,7 @@
 
 """Handling of lists of tests - common code to --load-list etc."""
 
-import six
+import io
 
 from extras import try_import
 bytestream_to_streamresult = try_import('subunit.ByteStreamToStreamResult')
@@ -26,7 +26,7 @@ def write_list(stream, test_ids):
     :param test_ids: An iterable of test ids.
     """
     # May need utf8 explicitly?
-    stream.write(six.binary_type((
+    stream.write(bytes((
         '\n'.join(list(test_ids) + [''])).encode('utf8')))
 
 
@@ -46,11 +46,11 @@ def parse_enumeration(enumeration_bytes):
 
 def _v1(list_bytes):
     return [id.strip() for id in list_bytes.decode('utf8').split(
-        six.text_type('\n')) if id.strip()]
+        str('\n')) if id.strip()]
 
 
 def _v2(list_bytes):
-    parser = bytestream_to_streamresult(six.BytesIO(list_bytes),
+    parser = bytestream_to_streamresult(io.BytesIO(list_bytes),
                                         non_subunit_name='stdout')
     result = stream_result()
     parser.run(result)

--- a/stestr/tests/repository/test_util.py
+++ b/stestr/tests/repository/test_util.py
@@ -10,10 +10,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import mock
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 from stestr.repository import util
 from stestr.tests import base

--- a/stestr/tests/test_bisect_return_codes.py
+++ b/stestr/tests/test_bisect_return_codes.py
@@ -15,8 +15,6 @@ import shutil
 import subprocess
 import tempfile
 
-import six
-
 from stestr.tests import base
 
 
@@ -65,7 +63,7 @@ class TestBisectReturnCodes(base.TestCase):
         out, err = p_analyze.communicate()
         out = out.decode('utf-8')
         # For debugging potential failures
-        lines = six.text_type(out.rstrip()).splitlines()
+        lines = str(out.rstrip()).splitlines()
         self.assertEqual(3, p_analyze.returncode,
                          'Analyze isolation returned an unexpected return code'
                          '\nStdout: %s\nStderr: %s' % (out, err))

--- a/stestr/tests/test_bisect_tests.py
+++ b/stestr/tests/test_bisect_tests.py
@@ -14,7 +14,6 @@ import io
 import operator
 
 import mock
-import six
 import subunit
 import testtools
 
@@ -80,7 +79,7 @@ class FakeNoFailing(FakeTestRun):
 
     def __init__(self, failure=True):
         # Generate a subunit stream
-        stream_buf = io.BytesIO(six.binary_type(b''))
+        stream_buf = io.BytesIO(bytes(b''))
         self._content = stream_buf.getvalue()
         self.id = None
 

--- a/stestr/tests/test_bisect_tests.py
+++ b/stestr/tests/test_bisect_tests.py
@@ -80,7 +80,7 @@ class FakeNoFailing(FakeTestRun):
 
     def __init__(self, failure=True):
         # Generate a subunit stream
-        stream_buf = io.BytesIO(six.binary_type(''.encode('utf-8')))
+        stream_buf = io.BytesIO(six.binary_type(b''))
         self._content = stream_buf.getvalue()
         self.id = None
 

--- a/stestr/tests/test_bisect_tests.py
+++ b/stestr/tests/test_bisect_tests.py
@@ -12,8 +12,8 @@
 
 import io
 import operator
+from unittest import mock
 
-import mock
 import subunit
 import testtools
 

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -10,8 +10,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from unittest import mock
+
 import ddt
-import mock
 
 from stestr import config_file
 from stestr.tests import base

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -21,8 +21,6 @@ import subprocess
 import tempfile
 
 import fixtures
-import six
-from six import StringIO
 import subunit as subunit_lib
 import testtools
 
@@ -55,8 +53,8 @@ class TestReturnCodes(base.TestCase):
         shutil.copy('stestr/tests/files/__init__.py', self.init_file)
         shutil.copy('stestr/tests/files/stestr.yaml', self.user_config)
 
-        self.stdout = StringIO()
-        self.stderr = StringIO()
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
         # Change directory, run wrapper and check result
         self.addCleanup(os.chdir, os.path.abspath(os.curdir))
         os.chdir(self.directory)
@@ -245,7 +243,7 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run passing', 0)
         stdout = self._get_cmd_stdout(
             'stestr last --no-subunit-trace')
-        stdout = six.text_type(stdout[0])
+        stdout = str(stdout[0])
         test_count_split = stdout.split(' ')
         test_count = test_count_split[1]
         test_count = int(test_count)
@@ -254,7 +252,7 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run --combine passing', 0)
         combine_stdout = self._get_cmd_stdout(
             'stestr last --no-subunit-trace')[0]
-        combine_stdout = six.text_type(combine_stdout)
+        combine_stdout = str(combine_stdout)
         combine_test_count_split = combine_stdout.split(' ')
         combine_test_count = combine_test_count_split[1]
         combine_test_count = int(combine_test_count)
@@ -303,7 +301,7 @@ class TestReturnCodes(base.TestCase):
     def test_no_subunit_trace_force_subunit_trace(self):
         out, err = self.assertRunExit(
             'stestr run --no-subunit-trace --force-subunit-trace passing', 0)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('PASSED (id=0)', out)
         self.assertIn('Totals', out)
         self.assertIn('Worker Balance', out)

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -95,7 +95,7 @@ class TestReturnCodes(base.TestCase):
         if not subunit:
             self.assertEqual(
                 p.returncode, expected,
-                "Stdout: %s; Stderr: %s" % (out, err))
+                "Stdout: {}; Stderr: {}".format(out, err))
             return (out, err)
         else:
             self.assertEqual(p.returncode, expected,
@@ -249,7 +249,7 @@ class TestReturnCodes(base.TestCase):
         test_count_split = stdout.split(' ')
         test_count = test_count_split[1]
         test_count = int(test_count)
-        id_regex = re.compile('\(id=(.*?)\)')
+        id_regex = re.compile(r'\(id=(.*?)\)')
         test_id = id_regex.search(stdout).group(0)
         self.assertRunExit('stestr run --combine passing', 0)
         combine_stdout = self._get_cmd_stdout(

--- a/stestr/tests/test_scheduler.py
+++ b/stestr/tests/test_scheduler.py
@@ -117,7 +117,7 @@ class TestScheduler(base.TestCase):
         if 'testdir.testfile.TestCase5.test' not in partitions[0]:
             self.assertTrue('testdir.testfile.TestCase5.test' in partitions[1])
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions(self):
         test_ids = ['test_a', 'test_b', 'your_test']
         fake_worker_yaml = [
@@ -132,7 +132,7 @@ class TestScheduler(base.TestCase):
         ]
         self.assertEqual(expected_grouping, groups)
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions_group_without_list(self):
         test_ids = ['test_a', 'test_b', 'your_test']
         fake_worker_yaml = [
@@ -143,7 +143,7 @@ class TestScheduler(base.TestCase):
             self.assertRaises(TypeError, scheduler.generate_worker_partitions,
                               test_ids, 'fakepath')
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions_no_worker_tag(self):
         test_ids = ['test_a', 'test_b', 'your_test']
         fake_worker_yaml = [
@@ -154,7 +154,7 @@ class TestScheduler(base.TestCase):
             self.assertRaises(TypeError, scheduler.generate_worker_partitions,
                               test_ids, 'fakepath')
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions_group_without_match(self):
         test_ids = ['test_a', 'test_b', 'your_test']
         fake_worker_yaml = [
@@ -170,7 +170,7 @@ class TestScheduler(base.TestCase):
         ]
         self.assertEqual(expected_grouping, groups)
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions_with_count(self):
         test_ids = ['test_a', 'test_b', 'your_test', 'a_thing1', 'a_thing2']
         fake_worker_yaml = [
@@ -189,7 +189,7 @@ class TestScheduler(base.TestCase):
         for worker in expected_grouping:
             self.assertIn(worker, groups)
 
-    @mock.patch('six.moves.builtins.open', mock.mock_open(), create=True)
+    @mock.patch('builtins.open', mock.mock_open(), create=True)
     def test_generate_worker_partitions_with_count_1(self):
         test_ids = ['test_a', 'test_b', 'your_test']
         fake_worker_yaml = [

--- a/stestr/tests/test_scheduler.py
+++ b/stestr/tests/test_scheduler.py
@@ -12,8 +12,8 @@
 
 import datetime
 import re
+from unittest import mock
 
-import mock
 from subunit import iso8601
 
 from stestr.repository import memory

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -108,7 +108,7 @@ class TestConstructList(base.TestCase):
             result = selection.construct_list(test_lists,
                                               whitelist_file='file')
         self.assertEqual(set(result),
-                         set(('fake_test1[tg]', 'fake_test2[tg]')))
+                         {'fake_test1[tg]', 'fake_test2[tg]'})
 
     def test_whitelist_invalid_regex(self):
         whitelist_file = six.StringIO()
@@ -133,7 +133,7 @@ class TestConstructList(base.TestCase):
                 result = selection.construct_list(test_lists, 'black_file',
                                                   'white_file', ['foo'])
         self.assertEqual(set(result),
-                         set(('fake_test1[tg]', 'fake_test3[tg,foo]')))
+                         {'fake_test1[tg]', 'fake_test3[tg,foo]'})
 
     def test_overlapping_black_regex(self):
 

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -12,8 +12,7 @@
 
 import io
 import re
-
-import mock
+from unittest import mock
 
 from stestr import selection
 from stestr.tests import base

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -10,10 +10,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import io
 import re
 
 import mock
-import six
 
 from stestr import selection
 from stestr.tests import base
@@ -41,12 +41,12 @@ class TestSelection(base.TestCase):
 
 class TestBlackReader(base.TestCase):
     def test_black_reader(self):
-        blacklist_file = six.StringIO()
+        blacklist_file = io.StringIO()
         for i in range(4):
             blacklist_file.write('fake_regex_%s\n' % i)
             blacklist_file.write('fake_regex_with_note_%s # note\n' % i)
         blacklist_file.seek(0)
-        with mock.patch('six.moves.builtins.open',
+        with mock.patch('builtins.open',
                         return_value=blacklist_file):
             result = selection.black_reader('fake_path')
         self.assertEqual(2 * 4, len(result))
@@ -60,10 +60,10 @@ class TestBlackReader(base.TestCase):
         self.assertEqual(note_cnt, 4)
 
     def test_invalid_regex(self):
-        blacklist_file = six.StringIO()
+        blacklist_file = io.StringIO()
         blacklist_file.write("fake_regex_with_bad_part[The-BAD-part]")
         blacklist_file.seek(0)
-        with mock.patch('six.moves.builtins.open',
+        with mock.patch('builtins.open',
                         return_value=blacklist_file):
             with mock.patch('sys.exit') as mock_exit:
                 selection.black_reader('fake_path')
@@ -111,10 +111,10 @@ class TestConstructList(base.TestCase):
                          {'fake_test1[tg]', 'fake_test2[tg]'})
 
     def test_whitelist_invalid_regex(self):
-        whitelist_file = six.StringIO()
+        whitelist_file = io.StringIO()
         whitelist_file.write("fake_regex_with_bad_part[The-BAD-part]")
         whitelist_file.seek(0)
-        with mock.patch('six.moves.builtins.open',
+        with mock.patch('builtins.open',
                         return_value=whitelist_file):
             with mock.patch('sys.exit') as mock_exit:
                 selection._get_regex_from_whitelist_file('fake_path')

--- a/stestr/tests/test_subunit_trace.py
+++ b/stestr/tests/test_subunit_trace.py
@@ -22,7 +22,6 @@ from ddt import data
 from ddt import ddt
 from ddt import unpack
 from mock import patch
-import six
 
 from stestr import subunit_trace
 from stestr.tests import base
@@ -79,7 +78,7 @@ class TestSubunitTrace(base.TestCase):
             'sample_streams/successful.subunit')
         bytes_ = io.BytesIO()
         with open(regular_stream, 'rb') as stream:
-            bytes_.write(six.binary_type(stream.read()))
+            bytes_.write(bytes(stream.read()))
         bytes_.seek(0)
         stdin = io.TextIOWrapper(io.BufferedReader(bytes_))
         returncode = subunit_trace.trace(stdin, sys.stdout)
@@ -91,7 +90,7 @@ class TestSubunitTrace(base.TestCase):
             'sample_streams/all_skips.subunit')
         bytes_ = io.BytesIO()
         with open(regular_stream, 'rb') as stream:
-            bytes_.write(six.binary_type(stream.read()))
+            bytes_.write(bytes(stream.read()))
         bytes_.seek(0)
         stdin = io.TextIOWrapper(io.BufferedReader(bytes_))
         returncode = subunit_trace.trace(stdin, sys.stdout)
@@ -103,7 +102,7 @@ class TestSubunitTrace(base.TestCase):
             'sample_streams/failure.subunit')
         bytes_ = io.BytesIO()
         with open(regular_stream, 'rb') as stream:
-            bytes_.write(six.binary_type(stream.read()))
+            bytes_.write(bytes(stream.read()))
         bytes_.seek(0)
         stdin = io.TextIOWrapper(io.BufferedReader(bytes_))
         returncode = subunit_trace.trace(stdin, sys.stdout)

--- a/stestr/tests/test_subunit_trace.py
+++ b/stestr/tests/test_subunit_trace.py
@@ -17,11 +17,11 @@ from datetime import datetime as dt
 import io
 import os
 import sys
+from unittest.mock import patch
 
 from ddt import data
 from ddt import ddt
 from ddt import unpack
-from mock import patch
 
 from stestr import subunit_trace
 from stestr.tests import base

--- a/stestr/tests/test_test_processor.py
+++ b/stestr/tests/test_test_processor.py
@@ -11,8 +11,7 @@
 # under the License.
 
 import subprocess
-
-import mock
+from unittest import mock
 
 from stestr import test_processor
 from stestr.tests import base

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -100,7 +100,7 @@ class TestUserConfig(base.TestCase):
         user_mock.assert_called_once_with(self.home_path)
 
     @mock.patch('yaml.safe_load', return_value={})
-    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    @mock.patch('builtins.open', mock.mock_open())
     def test_user_config_empty_schema(self, yaml_mock):
         user_conf = user_config.UserConfig('/path')
         self.assertEqual({}, user_conf.config)
@@ -108,7 +108,7 @@ class TestUserConfig(base.TestCase):
     @mock.patch('yaml.safe_load',
                 return_value={'init': {'subunit-trace': True}})
     @mock.patch('sys.exit')
-    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    @mock.patch('builtins.open', mock.mock_open())
     def test_user_config_invalid_command(self, exit_mock, yaml_mock):
         user_config.UserConfig('/path')
         error_string = ("Provided user config file /path is invalid because:\n"
@@ -118,7 +118,7 @@ class TestUserConfig(base.TestCase):
     @mock.patch('yaml.safe_load',
                 return_value={'run': {'subunit-trace': True}})
     @mock.patch('sys.exit')
-    @mock.patch('six.moves.builtins.open', mock.mock_open())
+    @mock.patch('builtins.open', mock.mock_open())
     def test_user_config_invalid_option(self, exit_mock, yaml_mock):
         user_config.UserConfig('/path')
         error_string = ("Provided user config file /path is invalid because:\n"
@@ -126,7 +126,7 @@ class TestUserConfig(base.TestCase):
                         "data['run']['subunit-trace']")
         exit_mock.assert_called_once_with(error_string)
 
-    @mock.patch('six.moves.builtins.open',
+    @mock.patch('builtins.open',
                 return_value=io.BytesIO(FULL_YAML.encode('utf-8')))
     def test_user_config_full_config(self, open_mock):
         user_conf = user_config.UserConfig('/path')
@@ -158,7 +158,7 @@ class TestUserConfig(base.TestCase):
         self.assertEqual(full_dict, user_conf.config)
 
     @mock.patch('sys.exit')
-    @mock.patch('six.moves.builtins.open',
+    @mock.patch('builtins.open',
                 return_value=io.BytesIO(INVALID_YAML_FIELD.encode('utf-8')))
     def test_user_config_invalid_value_type(self, open_mock, exit_mock):
         user_config.UserConfig('/path')
@@ -168,7 +168,7 @@ class TestUserConfig(base.TestCase):
         exit_mock.assert_called_once_with(error_string)
 
     @mock.patch('sys.exit')
-    @mock.patch('six.moves.builtins.open',
+    @mock.patch('builtins.open',
                 return_value=io.BytesIO(YAML_NOT_INT.encode('utf-8')))
     def test_user_config_invalid_integer(self, open_mock, exit_mock):
         user_config.UserConfig('/path')

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -12,8 +12,7 @@
 
 import io
 import os
-
-import mock
+from unittest import mock
 
 from stestr.tests import base
 from stestr import user_config

--- a/stestr/tests/test_user_config_return_codes.py
+++ b/stestr/tests/test_user_config_return_codes.py
@@ -77,7 +77,7 @@ class TestReturnCodes(base.TestCase):
         if not subunit:
             self.assertEqual(
                 p.returncode, expected,
-                "Stdout: %s; Stderr: %s" % (out, err))
+                "Stdout: {}; Stderr: {}".format(out, err))
             return (out, err)
         else:
             self.assertEqual(p.returncode, expected,

--- a/stestr/tests/test_user_config_return_codes.py
+++ b/stestr/tests/test_user_config_return_codes.py
@@ -17,8 +17,6 @@ import shutil
 import subprocess
 import tempfile
 
-import six
-from six import StringIO
 import subunit as subunit_lib
 import testtools
 import yaml
@@ -48,8 +46,8 @@ class TestReturnCodes(base.TestCase):
         shutil.copy('stestr/tests/files/setup.cfg', self.setup_cfg_file)
         shutil.copy('stestr/tests/files/__init__.py', self.init_file)
 
-        self.stdout = StringIO()
-        self.stderr = StringIO()
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
         # Change directory, run wrapper and check result
         self.addCleanup(os.chdir, os.path.abspath(os.curdir))
         os.chdir(self.directory)
@@ -123,7 +121,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'no-subunit-trace': True,
@@ -132,7 +130,7 @@ class TestReturnCodes(base.TestCase):
         conf_file.write(contents.encode('utf-8'))
         out, err = self.assertRunExit(
             'stestr --user-config=%s run passing' % path, 0)
-        out = six.text_type(out)
+        out = str(out)
         self.assertIn('PASSED (id=0)', out)
         self.assertNotIn('Totals', out)
         self.assertNotIn('Worker Balance', out)
@@ -144,7 +142,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'no-subunit-trace': True,
@@ -153,7 +151,7 @@ class TestReturnCodes(base.TestCase):
         conf_file.write(contents.encode('utf-8'))
         out, err = self.assertRunExit(
             'stestr --user-config=%s run' % path, 1)
-        out = six.text_type(out)
+        out = str(out)
         self.assertIn('FAILED (id=0, failures=2)', out)
         self.assertNotIn('Totals', out)
         self.assertNotIn('Worker Balance', out)
@@ -164,7 +162,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'no-subunit-trace': True,
@@ -174,7 +172,7 @@ class TestReturnCodes(base.TestCase):
         out, err = self.assertRunExit(
             'stestr --user-config=%s run --force-subunit-trace passing' % path,
             0)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('PASSED (id=0)', out)
         self.assertIn('Totals', out)
         self.assertIn('Worker Balance', out)
@@ -185,7 +183,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'abbreviate': True,
@@ -194,7 +192,7 @@ class TestReturnCodes(base.TestCase):
         conf_file.write(contents.encode('utf-8'))
         out, err = self.assertRunExit(
             'stestr --user-config=%s run passing' % path, 0)
-        out = six.text_type(out)
+        out = str(out)
         self.assertIn('..', out)
         self.assertNotIn('PASSED (id=0)', out)
         self.assertIn('Totals', out)
@@ -206,7 +204,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'abbreviate': True,
@@ -217,7 +215,7 @@ class TestReturnCodes(base.TestCase):
         # execution order for confirming the abbreviated output.
         out, err = self.assertRunExit(
             'stestr --user-config=%s run --serial' % path, 1)
-        out = six.text_type(out)
+        out = str(out)
         self.assertIn('FF..', out)
         self.assertNotIn('FAILED (id=0, failures=2)', out)
         self.assertIn('Totals', out)
@@ -229,7 +227,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'no-subunit-trace': True,
@@ -239,7 +237,7 @@ class TestReturnCodes(base.TestCase):
         conf_file.write(contents.encode('utf-8'))
         out, err = self.assertRunExit(
             'stestr --user-config=%s run passing' % path, 0)
-        out = six.text_type(out)
+        out = str(out)
         self.assertIn('PASSED (id=0)', out)
         self.assertNotIn('Totals', out)
         self.assertNotIn('Worker Balance', out)
@@ -251,7 +249,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'no-subunit-trace': True,
@@ -265,7 +263,7 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr --user-config=%s run' % path, 1)
         out, err = self.assertRunExit('stestr --user-config=%s failing' % path,
                                       1)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('FAILED (id=0, failures=2)', out)
         self.assertNotIn('FAIL:', out)
         self.assertIn('tests.test_failing.FakeTestClass.test_pass', out)
@@ -276,7 +274,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'slowest': True,
@@ -293,8 +291,8 @@ class TestReturnCodes(base.TestCase):
             'stestr --user-config=%s run passing' % path, 0)
         out, err = self.assertRunExit('stestr --user-config=%s last' % path,
                                       0)
-        run_out = six.text_type(run_out)
-        out = six.text_type(out)
+        run_out = str(run_out)
+        out = str(out)
         self.assertIn('PASSED (id=0)', out)
         self.assertNotIn('Totals', out)
         self.assertNotIn('Worker Balance', out)
@@ -310,7 +308,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'slowest': True,
@@ -332,7 +330,7 @@ class TestReturnCodes(base.TestCase):
             'stestr --user-config=%s last --subunit' % path)[0]
         out, err = self.assertRunExit('stestr --user-config=%s load' % path,
                                       0, stdin=stream)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('PASSED (id=0)', out)
         self.assertIn('Totals', out)
         self.assertIn('Worker Balance', out)
@@ -343,7 +341,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'slowest': True,
@@ -365,7 +363,7 @@ class TestReturnCodes(base.TestCase):
             'stestr --user-config=%s last --subunit' % path)[0]
         out, err = self.assertRunExit('stestr --user-config=%s load' % path,
                                       0, stdin=stream)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('FAILED (id=0, failures=2)', out)
         self.assertNotIn('FF..', out)
         self.assertIn('Totals', out)
@@ -378,7 +376,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'slowest': True,
@@ -400,7 +398,7 @@ class TestReturnCodes(base.TestCase):
             'stestr --user-config=%s last --subunit' % path)[0]
         out, err = self.assertRunExit('stestr --user-config=%s load' % path,
                                       0, stdin=stream)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('PASSED (id=0)', out)
         self.assertIn('..', out)
         self.assertIn('Totals', out)
@@ -413,7 +411,7 @@ class TestReturnCodes(base.TestCase):
         self.addCleanup(os.remove, path)
         conf_file = os.fdopen(fd, 'wb', 0)
         self.addCleanup(conf_file.close)
-        contents = six.text_type(
+        contents = str(
             yaml.dump({
                 'run': {
                     'slowest': True,
@@ -436,7 +434,7 @@ class TestReturnCodes(base.TestCase):
             'stestr --user-config=%s last --subunit' % path)[0]
         out, err = self.assertRunExit('stestr --user-config=%s load' % path,
                                       0, stdin=stream)
-        out = six.text_type(out)
+        out = str(out)
         self.assertNotIn('FAILED (id=0, failures=2)', out)
         self.assertIn('FF..', out)
         self.assertIn('Totals', out)

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -75,8 +75,8 @@ class UserConfig(object):
         try:
             self.schema(self.config)
         except vp.MultipleInvalid as e:
-            msg = 'Provided user config file {} is invalid because:\n{}'.format(
-                path, str(e))
+            msg = ('Provided user config file {} is invalid '
+                   'because:\n{}'.format(path, str(e)))
             sys.exit(msg)
 
     @property

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -75,7 +75,7 @@ class UserConfig(object):
         try:
             self.schema(self.config)
         except vp.MultipleInvalid as e:
-            msg = 'Provided user config file %s is invalid because:\n%s' % (
+            msg = 'Provided user config file {} is invalid because:\n{}'.format(
                 path, str(e))
             sys.exit(msg)
 

--- a/stestr/utils.py
+++ b/stestr/utils.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import six
+import io
 
 from stestr import output
 
@@ -70,7 +70,7 @@ def _iter_internal_streams(input_streams, stream_type):
         elif getattr(stream_value, 'read', None):
             yield stream_value
         else:
-            yield six.BytesIO(stream_value)
+            yield io.BytesIO(stream_value)
 
 
 def iter_streams(input_streams, stream_type):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,9 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 hacking<1.2.0,>=1.1.0
-sphinx!=1.6.6,!=1.6.7,<2.0.0;python_version=='2.7'  # BSD
-sphinx!=1.6.6,!=1.6.7,!=2.1.0;python_version>='3.4'  # BSD
-mock>=2.0 # BSD
+sphinx>2.1.0 # BSD
 subunit2sql>=1.8.0
 coverage>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT

--- a/tools/testr_to_stestr.py
+++ b/tools/testr_to_stestr.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import configparser
 import os
 import sys
 
-import six
 
 if not os.path.isfile('.testr.conf'):
     sys.exit("Testr config file not found")
 
 with open('.testr.conf', 'r') as testr_conf_file:
-    config = six.moves.configparser.ConfigParser()
+    config = configparser.ConfigParser()
     config.readfp(testr_conf_file)
 
     test_command = config.get('DEFAULT', 'test_command')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py38,py37,py36,py35,py34,py27,pep8
+envlist = py38,py37,py36,py35,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit remove 2.7 support from stestr. This has been advertised since the 2.4.0 release as happening in early 2020 (corresponding to the upstream EoL of python 2.7). It also takes the opportunity to remove all the 2.7 compat code left in the repo which is now no longer necessary.

Fixes #237 