### PR TITLE
Bump python-subunit minimum to 1.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 future
 pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
-python-subunit>=1.3.0 # Apache-2.0/BSD
+python-subunit>=1.4.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD
 six>=1.10.0 # MIT
 testtools>=2.2.0 # MIT


### PR DESCRIPTION
This version includes an important Python 3 fix [1], without which a Python 3-only stestr doesn't really make sense.

[1] https://github.com/testing-cabal/subunit/pull/40