### PR TITLE
Remove universal flag from release job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - TWINE_USERNAME=stestr-release
       install: pip install -U twine
       script:
-        - python3 setup.py sdist bdist_wheel --universal
+        - python3 setup.py sdist bdist_wheel
         - twine upload dist/stestr*
 
 cache:


### PR DESCRIPTION
Now that we've dropped support for python 2.7 from stestr we're no
longer advertising or building universal wheels. However we never
updated the travis job which publishes the release to pypi to drop the
--universal flag when it builds the wheel for release. This commit
corrects the oversight so that in future releases we don't try to build
a universal wheel.