### PR TITLE
use python-requires metadata instead of requires-python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-requires-python = >=3.5
+python-requires = >=3.5
 
 [files]
 packages =


### PR DESCRIPTION
Here is the doc with right name -
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires