### PR TITLE
Change option '--whitelist-file' to '--include-list'

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -171,19 +171,25 @@ used in conjunction with the normal filters then the regex filters passed in as
 an argument regex will be used for the initial test selection, and the
 exclusion regexes from the blacklist file on top of that.
 
-The dual of the blacklist file is the whitelist file which will include any
-tests matching the regexes in the file. You can specify the path to the file
-with ``--whitelist-file``/``-w``, for example::
+The dual of the blacklist file is the inclusion list file which will include
+any tests matching the regexes in the file. You can specify the path to the
+file with ``--include-list``/``-i``, for example::
 
-  $ stestr run --whitelist-file $path_to_file
+  $ stestr run --include-list $path_to_file
 
 The format for the file is more or less identical to the blacklist file::
 
-  # Whitelist File
+  # Inclusion list File
   ^regex1 # Include these tests
   .*regex2 # include those tests
 
 However, instead of excluding the matches it will include them.
+
+.. note::
+    DEPRACATION WARNING:
+    Previously the option ``--whitelist-file``/``-w`` was available for this
+    functionality. While it is still available at this time, it is soon to be
+    replaced by the new (equivalent) option ``--include-list``/``-i``.
 
 It's also worth noting that you can use the test list option to dry run any
 selection arguments you are using. You just need to use ``stestr list``

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -172,7 +172,7 @@ passed in as an argument regex will be used for the initial test selection, and
 the exclusion regexes from the exclusion list file on top of that.
 
 .. note::
-    DEPRACATION WARNING:
+    DEPRECATION WARNING:
     Previously the option ``--blacklist-file``/``-b`` was available for this
     functionality. While it is still available at this time, it is soon to be
     replaced by the new (equivalent) option ``--exclude-list``/``-e``.
@@ -192,7 +192,7 @@ The format for the file is more or less identical to the exclusion list file::
 However, instead of excluding the matches it will include them.
 
 .. note::
-    DEPRACATION WARNING:
+    DEPRECATION WARNING:
     Previously the option ``--whitelist-file``/``-w`` was available for this
     functionality. While it is still available at this time, it is soon to be
     replaced by the new (equivalent) option ``--include-list``/``-i``.

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -138,14 +138,14 @@ filters will be run. For example, if you called ``stestr run foo bar`` this
 will only run the tests that have a regex match with foo **or** a regex match
 with bar.
 
-stestr allows you do to do simple test exclusion via passing a rejection/black
-regexp::
+stestr allows you do to do simple test exclusion via passing a rejection or
+exclusion regexp::
 
-  $ stestr run --black-regex 'slow_tests|bad_tests'
+  $ stestr run --exclusion-regex 'slow_tests|bad_tests'
 
 stestr also allow you to combine these arguments::
 
-  $ stestr run --black-regex 'slow_tests|bad_tests' ui\.interface
+  $ stestr run --exclusion-regex 'slow_tests|bad_tests' ui\.interface
 
 Here first we selected all tests which matches to ``ui\.interface``, then we
 are dropping all test which matches ``slow_tests|bad_tests`` from the final

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -138,7 +138,7 @@ filters will be run. For example, if you called ``stestr run foo bar`` this
 will only run the tests that have a regex match with foo **or** a regex match
 with bar.
 
-stestr allows you do to do simple test exclusion via passing a rejection or
+stestr allows you do to do simple test exclusion via passing a
 exclusion regexp::
 
   $ stestr run --exclusion-regex 'slow_tests|bad_tests'

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -141,11 +141,11 @@ with bar.
 stestr allows you do to do simple test exclusion via passing a
 exclusion regexp::
 
-  $ stestr run --exclusion-regex 'slow_tests|bad_tests'
+  $ stestr run --exclude-regex 'slow_tests|bad_tests'
 
 stestr also allow you to combine these arguments::
 
-  $ stestr run --exclusion-regex 'slow_tests|bad_tests' ui\.interface
+  $ stestr run --exclude-regex 'slow_tests|bad_tests' ui\.interface
 
 Here first we selected all tests which matches to ``ui\.interface``, then we
 are dropping all test which matches ``slow_tests|bad_tests`` from the final

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -165,9 +165,9 @@ start of a comment on a line. For example::
   .*regex2 # exclude those tests
 
 The regexp used in the exclusion list file or passed as argument, will be used
-to drop tests from the initial selection list. It will generate a list which will
-exclude any tests matching ``^regex1`` or ``.*regex2``. If an exclusion list
-file is used in conjunction with the normal filters then the regex filters
+to drop tests from the initial selection list. It will generate a list which
+will exclude any tests matching ``^regex1`` or ``.*regex2``. If an exclusion
+list file is used in conjunction with the normal filters then the regex filters
 passed in as an argument regex will be used for the initial test selection, and
 the exclusion regexes from the exclusion list file on top of that.
 

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -151,33 +151,39 @@ Here first we selected all tests which matches to ``ui\.interface``, then we
 are dropping all test which matches ``slow_tests|bad_tests`` from the final
 list.
 
-stestr also allows you to specify a blacklist file to define a set of regexes
-to exclude. You can specify a blacklist file with the
-``--blacklist-file``/``-b`` option, for example::
+stestr also allows you to specify an exclusion list file to define a set of
+regexes to exclude. You can specify an exclusion list file with the
+``--exclude-list``/``-e`` option, for example::
 
-  $ stestr run --blacklist-file $path_to_file
+  $ stestr run --exclude-list $path_to_file
 
 The format for the file is line separated regex, with ``#`` used to signify the
 start of a comment on a line. For example::
 
-  # Blacklist File
+  # Exclusion list File
   ^regex1 # Excludes these tests
   .*regex2 # exclude those tests
 
-The regexp used in the blacklist file or passed as argument, will be used to
-drop tests from the initial selection list. It will generate a list which will
-exclude any tests matching ``^regex1`` or ``.*regex2``. If a blacklist file is
-used in conjunction with the normal filters then the regex filters passed in as
-an argument regex will be used for the initial test selection, and the
-exclusion regexes from the blacklist file on top of that.
+The regexp used in the exclusion list file or passed as argument, will be used
+to drop tests from the initial selection list. It will generate a list which will
+exclude any tests matching ``^regex1`` or ``.*regex2``. If an exclusion list
+file is used in conjunction with the normal filters then the regex filters
+passed in as an argument regex will be used for the initial test selection, and
+the exclusion regexes from the exclusion list file on top of that.
 
-The dual of the blacklist file is the inclusion list file which will include
-any tests matching the regexes in the file. You can specify the path to the
-file with ``--include-list``/``-i``, for example::
+.. note::
+    DEPRACATION WARNING:
+    Previously the option ``--blacklist-file``/``-b`` was available for this
+    functionality. While it is still available at this time, it is soon to be
+    replaced by the new (equivalent) option ``--exclude-list``/``-e``.
+
+The dual of the exclusion list file is the inclusion list file which will
+include any tests matching the regexes in the file. You can specify the path to
+the file with ``--include-list``/``-i``, for example::
 
   $ stestr run --include-list $path_to_file
 
-The format for the file is more or less identical to the blacklist file::
+The format for the file is more or less identical to the exclusion list file::
 
   # Inclusion list File
   ^regex1 # Include these tests
@@ -195,7 +201,7 @@ It's also worth noting that you can use the test list option to dry run any
 selection arguments you are using. You just need to use ``stestr list``
 with your selection options to do this, for example::
 
-  $ stestr list 'regex3.*' --blacklist-file blacklist.txt
+  $ stestr list 'regex3.*' --exclude-list exclusion_list.txt
 
 This will list all the tests which will be run by stestr using that combination
 of arguments.

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -56,11 +56,16 @@ class List(command.Command):
                                  'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B',
                             default=None, dest='black_regex',
+                            help='DEPRECATED: This option will soon be  '
+                            'replaced by --exclusion-regex which is '
+                            'functionally equivalent.')
+        parser.add_argument('--exclusion-regex', '-E',
+                            default=None, dest='exclusion_regex',
                             help='Test rejection regex. If a test cases name '
                             'matches on re.search() operation , '
                             'it will be removed from the final test list. '
-                            'Effectively the black-regexp is added to '
-                            ' black regexp list, but you do need to edit a '
+                            'Effectively the exclusion-regexp is added to '
+                            'exclusion regexp list, but you do need to edit a '
                             'file. The exclusion filtering happens after the '
                             'initial safe list selection, which by default is '
                             'everything.')
@@ -80,6 +85,7 @@ class List(command.Command):
                             whitelist_file=args.whitelist_file,
                             inclusion_list_file=args.inclusion_list_file,
                             black_regex=args.black_regex,
+                            exclusion_regex=args.exclusion_regex,
                             filters=filters)
 
 
@@ -87,7 +93,8 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
                  blacklist_file=None, exclusion_list_file=None,
                  whitelist_file=None, inclusion_list_file=None,
-                 black_regex=None, filters=None, stdout=sys.stdout):
+                 black_regex=None, exclusion_regex=None, filters=None,
+                 stdout=sys.stdout):
     """Print a list of test_ids for a project
 
     This function will print the test_ids for tests in a project. You can
@@ -115,8 +122,11 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         option inclusion_list_file below.
     :param str inclusion_list_file: Path to an inclusion list file, this file
         contains a separate regex on each newline.
-    :param str black_regex: Test rejection regex. If a test cases name matches
-        on re.search() operation, it will be removed from the final test list.
+    :param str black_regex: DEPRECATED: soon to be replaced by the new
+        option exclusion_regex below.
+    :param str exclusion_regex: Test rejection regex. If a test cases name
+        matches on re.search() operation, it will be removed from the final
+        test list.
     :param list filters: A list of string regex filters to initially apply on
         the test list. Tests that match any of the regexes will be used.
         (assuming any other filtering specified also uses it)
@@ -131,10 +141,12 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         repo_url=repo_url, group_regex=group_regex,
         blacklist_file=blacklist_file, exclusion_list_file=exclusion_list_file,
         whitelist_file=whitelist_file, inclusion_list_file=inclusion_list_file,
-        black_regex=black_regex, test_path=test_path, top_dir=top_dir)
+        black_regex=black_regex, exclusion_regex=exclusion_regex,
+        test_path=test_path, top_dir=top_dir)
     not_filtered = filters is None and blacklist_file is None\
         and whitelist_file is None and black_regex is None\
-        and inclusion_list_file is None and exclusion_list_file is None
+        and inclusion_list_file is None and exclusion_list_file is None\
+        and exclusion_regex is None
     try:
         cmd.setUp()
         # List tests if the fixture has not already needed to to filter.

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -42,7 +42,12 @@ class List(command.Command):
                                  'newline')
         parser.add_argument('--whitelist-file', '-w',
                             default=None, dest='whitelist_file',
-                            help='Path to a whitelist file, this file '
+                            help='DEPRECATED: This option will soon be  '
+                                 'replaced by --include-list which is '
+                                 'functionally equivalent.')
+        parser.add_argument('--include-list', '-i',
+                            default=None, dest='inclusion_list_file',
+                            help='Path to an inclusion list file, this file '
                                  'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B',
                             default=None, dest='black_regex',
@@ -52,7 +57,7 @@ class List(command.Command):
                             'Effectively the black-regexp is added to '
                             ' black regexp list, but you do need to edit a '
                             'file. The black filtering happens after the '
-                            'initial white selection, which by default is '
+                            'initial safe list selection, which by default is '
                             'everything.')
         return parser
 
@@ -67,14 +72,16 @@ class List(command.Command):
                             top_dir=self.app_args.top_dir,
                             blacklist_file=args.blacklist_file,
                             whitelist_file=args.whitelist_file,
+                            inclusion_list_file=args.inclusion_list_file,
                             black_regex=args.black_regex,
                             filters=filters)
 
 
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
-                 blacklist_file=None, whitelist_file=None, black_regex=None,
-                 filters=None, stdout=sys.stdout):
+                 blacklist_file=None, whitelist_file=None,
+                 inclusion_list_file=None,
+                 black_regex=None, filters=None, stdout=sys.stdout):
     """Print a list of test_ids for a project
 
     This function will print the test_ids for tests in a project. You can
@@ -96,8 +103,10 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         config file option are set this value will be used.
     :param str blacklist_file: Path to a blacklist file, this file contains a
         separate regex exclude on each newline.
-    :param str whitelist_file: Path to a whitelist file, this file contains a
-        separate regex on each newline.
+    :param str whitelist_file: DEPRECATED: soon to be replaced by the new
+        option inclusion_list_file below.
+    :param str inclusion_list_file: Path to an inclusion list file, this file
+        contains a separate regex on each newline.
     :param str black_regex: Test rejection regex. If a test cases name matches
         on re.search() operation, it will be removed from the final test list.
     :param list filters: A list of string regex filters to initially apply on
@@ -113,9 +122,11 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         regexes=filters, repo_type=repo_type,
         repo_url=repo_url, group_regex=group_regex,
         blacklist_file=blacklist_file, whitelist_file=whitelist_file,
+        inclusion_list_file=inclusion_list_file,
         black_regex=black_regex, test_path=test_path, top_dir=top_dir)
     not_filtered = filters is None and blacklist_file is None\
-        and whitelist_file is None and black_regex is None
+        and whitelist_file is None and black_regex is None\
+        and inclusion_list_file is None
     try:
         cmd.setUp()
         # List tests if the fixture has not already needed to to filter.

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -40,7 +40,10 @@ class List(command.Command):
                             default=None, dest='blacklist_file',
                             help='DEPRECATED: This option will soon be  '
                                  'replaced by --exclude-list which is '
-                                 'functionally equivalent.')
+                                 'functionally equivalent. If this is '
+                                 'specified at the same time as '
+                                 '--exclude-list, this flag will be ignored '
+                                 'and --exclude-list will be used')
         parser.add_argument('--exclude-list', '-e',
                             default=None, dest='exclude_list',
                             help='Path to an exclusion list file, this file '
@@ -50,7 +53,10 @@ class List(command.Command):
                             default=None, dest='whitelist_file',
                             help='DEPRECATED: This option will soon be  '
                                  'replaced by --include-list which is '
-                                 'functionally equivalent.')
+                                 'functionally equivalent. If this is '
+                                 'specified at the same time as '
+                                 '--include-list, this flag will be ignored '
+                                 'and --include-list will be used')
         parser.add_argument('--include-list', '-i',
                             default=None, dest='include_list',
                             help='Path to an inclusion list file, this file '
@@ -59,7 +65,9 @@ class List(command.Command):
                             default=None, dest='black_regex',
                             help='DEPRECATED: This option will soon be  '
                             'replaced by --exclude-regex which is '
-                            'functionally equivalent.')
+                            'functionally equivalent. If this is specified at '
+                            'the same time as --exclude-regex, this flag will '
+                            'be ignored and --exclude-regex will be used')
         parser.add_argument('--exclude-regex', '-E',
                             default=None, dest='exclude_regex',
                             help='Test rejection regex. If a test cases name '
@@ -116,15 +124,18 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         together in the stestr scheduler. If both this and the corresponding
         config file option are set this value will be used.
     :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclude_list below.
+        option exclude_list below. If this is specified at the same time as
+        exclude_list , this flag will be ignored and exclude_list will be used
     :param str exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option include_list below.
+        option include_list below. If this is specified at the same time as
+        include_list , this flag will be ignored and include_list will be used
     :param str include_list: Path to an inclusion list file, this file
         contains a separate regex on each newline.
     :param str black_regex: DEPRECATED: soon to be replaced by the new
-        option exclude_regex below.
+        option exclude_regex below. If this is specified at the same time as
+        exclude_regex, this flag will be ignored and exclude_regex will be used
     :param str exclude_regex: Test rejection regex. If a test cases name
         matches on re.search() operation, it will be removed from the final
         test list.

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -14,6 +14,7 @@
 
 from io import BytesIO
 import sys
+import warnings
 
 from cliff import command
 
@@ -41,7 +42,7 @@ class List(command.Command):
                                  'replaced by --exclude-list which is '
                                  'functionally equivalent.')
         parser.add_argument('--exclude-list', '-e',
-                            default=None, dest='exclusion_list_file',
+                            default=None, dest='exclude_list',
                             help='Path to an exclusion list file, this file '
                                  'contains a separate regex exclude on each '
                                  'newline')
@@ -51,16 +52,16 @@ class List(command.Command):
                                  'replaced by --include-list which is '
                                  'functionally equivalent.')
         parser.add_argument('--include-list', '-i',
-                            default=None, dest='inclusion_list_file',
+                            default=None, dest='include_list',
                             help='Path to an inclusion list file, this file '
                                  'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B',
                             default=None, dest='black_regex',
                             help='DEPRECATED: This option will soon be  '
-                            'replaced by --exclusion-regex which is '
+                            'replaced by --exclude-regex which is '
                             'functionally equivalent.')
-        parser.add_argument('--exclusion-regex', '-E',
-                            default=None, dest='exclusion_regex',
+        parser.add_argument('--exclude-regex', '-E',
+                            default=None, dest='exclude_regex',
                             help='Test rejection regex. If a test cases name '
                             'matches on re.search() operation , '
                             'it will be removed from the final test list. '
@@ -81,19 +82,19 @@ class List(command.Command):
                             test_path=self.app_args.test_path,
                             top_dir=self.app_args.top_dir,
                             blacklist_file=args.blacklist_file,
-                            exclusion_list_file=args.exclusion_list_file,
+                            exclude_list=args.exclude_list,
                             whitelist_file=args.whitelist_file,
-                            inclusion_list_file=args.inclusion_list_file,
+                            include_list=args.include_list,
                             black_regex=args.black_regex,
-                            exclusion_regex=args.exclusion_regex,
+                            exclude_regex=args.exclude_regex,
                             filters=filters)
 
 
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
-                 blacklist_file=None, exclusion_list_file=None,
-                 whitelist_file=None, inclusion_list_file=None,
-                 black_regex=None, exclusion_regex=None, filters=None,
+                 blacklist_file=None, exclude_list=None,
+                 whitelist_file=None, include_list=None,
+                 black_regex=None, exclude_regex=None, filters=None,
                  stdout=sys.stdout):
     """Print a list of test_ids for a project
 
@@ -115,16 +116,16 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         together in the stestr scheduler. If both this and the corresponding
         config file option are set this value will be used.
     :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclusion_list_file below.
-    :param str exclusion_list_file: Path to an exclusion list file, this file
+        option exclude_list below.
+    :param str exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option inclusion_list_file below.
-    :param str inclusion_list_file: Path to an inclusion list file, this file
+        option include_list below.
+    :param str include_list: Path to an inclusion list file, this file
         contains a separate regex on each newline.
     :param str black_regex: DEPRECATED: soon to be replaced by the new
-        option exclusion_regex below.
-    :param str exclusion_regex: Test rejection regex. If a test cases name
+        option exclude_regex below.
+    :param str exclude_regex: Test rejection regex. If a test cases name
         matches on re.search() operation, it will be removed from the final
         test list.
     :param list filters: A list of string regex filters to initially apply on
@@ -134,19 +135,34 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         this is sys.stdout
 
     """
+    if blacklist_file is not None:
+        warnings.warn("The blacklist-file argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "exclude-list which is functionally equivalent",
+                      DeprecationWarning)
+    if whitelist_file is not None:
+        warnings.warn("The whitelist-file argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "include-list which is functionally equivalent",
+                      DeprecationWarning)
+    if black_regex is not None:
+        warnings.warn("The black-regex argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "exclude-regex which is functionally equivalent",
+                      DeprecationWarning)
     ids = None
     conf = config_file.TestrConf(config)
     cmd = conf.get_run_command(
         regexes=filters, repo_type=repo_type,
         repo_url=repo_url, group_regex=group_regex,
-        blacklist_file=blacklist_file, exclusion_list_file=exclusion_list_file,
-        whitelist_file=whitelist_file, inclusion_list_file=inclusion_list_file,
-        black_regex=black_regex, exclusion_regex=exclusion_regex,
+        blacklist_file=blacklist_file, exclude_list=exclude_list,
+        whitelist_file=whitelist_file, include_list=include_list,
+        black_regex=black_regex, exclude_regex=exclude_regex,
         test_path=test_path, top_dir=top_dir)
     not_filtered = filters is None and blacklist_file is None\
         and whitelist_file is None and black_regex is None\
-        and inclusion_list_file is None and exclusion_list_file is None\
-        and exclusion_regex is None
+        and include_list is None and exclude_list is None\
+        and exclude_regex is None
     try:
         cmd.setUp()
         # List tests if the fixture has not already needed to to filter.

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -37,7 +37,12 @@ class List(command.Command):
                             "filtering specified also uses it)")
         parser.add_argument('--blacklist-file', '-b',
                             default=None, dest='blacklist_file',
-                            help='Path to a blacklist file, this file '
+                            help='DEPRECATED: This option will soon be  '
+                                 'replaced by --exclude-list which is '
+                                 'functionally equivalent.')
+        parser.add_argument('--exclude-list', '-e',
+                            default=None, dest='exclusion_list_file',
+                            help='Path to an exclusion list file, this file '
                                  'contains a separate regex exclude on each '
                                  'newline')
         parser.add_argument('--whitelist-file', '-w',
@@ -56,7 +61,7 @@ class List(command.Command):
                             'it will be removed from the final test list. '
                             'Effectively the black-regexp is added to '
                             ' black regexp list, but you do need to edit a '
-                            'file. The black filtering happens after the '
+                            'file. The exclusion filtering happens after the '
                             'initial safe list selection, which by default is '
                             'everything.')
         return parser
@@ -71,6 +76,7 @@ class List(command.Command):
                             test_path=self.app_args.test_path,
                             top_dir=self.app_args.top_dir,
                             blacklist_file=args.blacklist_file,
+                            exclusion_list_file=args.exclusion_list_file,
                             whitelist_file=args.whitelist_file,
                             inclusion_list_file=args.inclusion_list_file,
                             black_regex=args.black_regex,
@@ -79,8 +85,8 @@ class List(command.Command):
 
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
-                 blacklist_file=None, whitelist_file=None,
-                 inclusion_list_file=None,
+                 blacklist_file=None, exclusion_list_file=None,
+                 whitelist_file=None, inclusion_list_file=None,
                  black_regex=None, filters=None, stdout=sys.stdout):
     """Print a list of test_ids for a project
 
@@ -101,8 +107,10 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
     :param str group_regex: Set a group regex to use for grouping tests
         together in the stestr scheduler. If both this and the corresponding
         config file option are set this value will be used.
-    :param str blacklist_file: Path to a blacklist file, this file contains a
-        separate regex exclude on each newline.
+    :param str blacklist_file: DEPRECATED: soon to be replaced by the new
+        option exclusion_list_file below.
+    :param str exclusion_list_file: Path to an exclusion list file, this file
+        contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
         option inclusion_list_file below.
     :param str inclusion_list_file: Path to an inclusion list file, this file
@@ -121,12 +129,12 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
     cmd = conf.get_run_command(
         regexes=filters, repo_type=repo_type,
         repo_url=repo_url, group_regex=group_regex,
-        blacklist_file=blacklist_file, whitelist_file=whitelist_file,
-        inclusion_list_file=inclusion_list_file,
+        blacklist_file=blacklist_file, exclusion_list_file=exclusion_list_file,
+        whitelist_file=whitelist_file, inclusion_list_file=inclusion_list_file,
         black_regex=black_regex, test_path=test_path, top_dir=top_dir)
     not_filtered = filters is None and blacklist_file is None\
         and whitelist_file is None and black_regex is None\
-        and inclusion_list_file is None
+        and inclusion_list_file is None and exclusion_list_file is None
     try:
         cmd.setUp()
         # List tests if the fixture has not already needed to to filter.

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -122,11 +122,16 @@ class Run(command.Command):
                             'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B', default=None,
                             dest='black_regex',
+                            help='DEPRECATED: This option will soon be '
+                            'replaced by --exclusion-regex which is '
+                            'functionally equivalent.')
+        parser.add_argument('--exclusion-regex', '-E', default=None,
+                            dest='exclusion_regex',
                             help='Test rejection regex. If a test cases name '
                             'matches on re.search() operation , '
                             'it will be removed from the final test list. '
-                            'Effectively the black-regexp is added to '
-                            ' black regexp list, but you do need to edit a '
+                            'Effectively the exclusion-regexp is added to '
+                            'exclusion regexp list, but you do need to edit a '
                             'file. The exclusion filtering happens after the '
                             'initial safe list selection, which by default is '
                             'everything.')
@@ -254,8 +259,8 @@ class Run(command.Command):
             exclusion_list_file=args.exclusion_list_file,
             whitelist_file=args.whitelist_file,
             inclusion_list_file=args.inclusion_list_file,
-            black_regex=args.black_regex, no_discover=args.no_discover,
-            random=random, combine=args.combine,
+            black_regex=args.black_regex, exclusion_regex=args.exclusion_regex,
+            no_discover=args.no_discover, random=random, combine=args.combine,
             filters=filters, pretty_out=pretty_out, color=color,
             stdout=stdout, abbreviate=abbreviate,
             suppress_attachments=suppress_attachments,
@@ -300,9 +305,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                 analyze_isolation=False, isolated=False, worker_path=None,
                 blacklist_file=None, exclusion_list_file=None,
                 whitelist_file=None, inclusion_list_file=None,
-                black_regex=None, no_discover=False, random=False,
-                combine=False, filters=None, pretty_out=True, color=False,
-                stdout=sys.stdout, abbreviate=False,
+                black_regex=None, exclusion_regex=None, no_discover=False,
+                random=False, combine=False, filters=None, pretty_out=True,
+                color=False, stdout=sys.stdout, abbreviate=False,
                 suppress_attachments=False, all_attachments=False,
                 show_binary_attachments=True, pdb=False):
     """Function to execute the run command
@@ -350,8 +355,11 @@ def run_command(config='.stestr.conf', repo_type='file',
         option inclusion_list_file below.
     :param str inclusion_list_file: Path to a inclusion list file, this file
         contains a separate regex on each newline.
-    :param str black_regex: Test rejection regex. If a test cases name matches
-        on re.search() operation, it will be removed from the final test list.
+    :param str black_regex: DEPRECATED: soon to be replaced by the new
+        option exclusion_regex below.
+    :param str exclusion_regex: Test rejection regex. If a test cases name
+        matches on re.search() operation, it will be removed from the final
+        test list.
     :param str no_discover: Takes in a single test_id to bypasses test
         discover and just execute the test specified. A file name may be used
         in place of a test name.
@@ -530,6 +538,7 @@ def run_command(config='.stestr.conf', repo_type='file',
             exclusion_list_file=exclusion_list_file,
             whitelist_file=whitelist_file,
             inclusion_list_file=inclusion_list_file, black_regex=black_regex,
+            exclusion_regex=exclusion_regex,
             top_dir=top_dir, test_path=test_path, randomize=random)
         if isolated:
             result = 0
@@ -548,7 +557,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                     exclusion_list_file=exclusion_list_file,
                     whitelist_file=whitelist_file,
                     inclusion_list_file=inclusion_list_file,
-                    black_regex=black_regex,
+                    black_regex=black_regex, exclusion_regex=exclusion_regex,
                     randomize=random, test_path=test_path, top_dir=top_dir)
 
                 run_result = _run_tests(
@@ -590,8 +599,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                 exclusion_list_file=exclusion_list_file,
                 whitelist_file=whitelist_file,
                 inclusion_list_file=inclusion_list_file,
-                black_regex=black_regex, randomize=random, test_path=test_path,
-                top_dir=top_dir)
+                black_regex=black_regex, exclusion_regex=exclusion_regex,
+                randomize=random, test_path=test_path, top_dir=top_dir)
             if not _run_tests(cmd, until_failure):
                 # If the test was filtered, it won't have been run.
                 if test_id in repo.get_test_ids(repo.latest_id()):

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -107,7 +107,7 @@ class Run(command.Command):
                             'replaced by --exclude-list which is functionally '
                             'equivalent.')
         parser.add_argument('--exclude-list', '-e',
-                            default=None, dest='exclusion_list_file',
+                            default=None, dest='exclude_list',
                             help='Path to an exclusion list file, this file '
                             'contains a separate regex exclude on each '
                             'newline')
@@ -117,16 +117,16 @@ class Run(command.Command):
                             'replaced by --include-list which is functionally '
                             'equivalent.')
         parser.add_argument('--include-list', '-i',
-                            default=None, dest='inclusion_list_file',
+                            default=None, dest='include_list',
                             help='Path to an inclusion list file, this file '
                             'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B', default=None,
                             dest='black_regex',
                             help='DEPRECATED: This option will soon be '
-                            'replaced by --exclusion-regex which is '
+                            'replaced by --exclude-regex which is '
                             'functionally equivalent.')
-        parser.add_argument('--exclusion-regex', '-E', default=None,
-                            dest='exclusion_regex',
+        parser.add_argument('--exclude-regex', '-E', default=None,
+                            dest='exclude_regex',
                             help='Test rejection regex. If a test cases name '
                             'matches on re.search() operation , '
                             'it will be removed from the final test list. '
@@ -256,10 +256,9 @@ class Run(command.Command):
             subunit_out=args.subunit, until_failure=args.until_failure,
             analyze_isolation=args.analyze_isolation, isolated=args.isolated,
             worker_path=args.worker_path, blacklist_file=args.blacklist_file,
-            exclusion_list_file=args.exclusion_list_file,
-            whitelist_file=args.whitelist_file,
-            inclusion_list_file=args.inclusion_list_file,
-            black_regex=args.black_regex, exclusion_regex=args.exclusion_regex,
+            exclude_list=args.exclude_list, whitelist_file=args.whitelist_file,
+            include_list=args.include_list,
+            black_regex=args.black_regex, exclude_regex=args.exclude_regex,
             no_discover=args.no_discover, random=random, combine=args.combine,
             filters=filters, pretty_out=pretty_out, color=color,
             stdout=stdout, abbreviate=abbreviate,
@@ -303,9 +302,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                 failing=False, serial=False, concurrency=0, load_list=None,
                 partial=False, subunit_out=False, until_failure=False,
                 analyze_isolation=False, isolated=False, worker_path=None,
-                blacklist_file=None, exclusion_list_file=None,
-                whitelist_file=None, inclusion_list_file=None,
-                black_regex=None, exclusion_regex=None, no_discover=False,
+                blacklist_file=None, exclude_list=None,
+                whitelist_file=None, include_list=None,
+                black_regex=None, exclude_regex=None, no_discover=False,
                 random=False, combine=False, filters=None, pretty_out=True,
                 color=False, stdout=sys.stdout, abbreviate=False,
                 suppress_attachments=False, all_attachments=False,
@@ -348,16 +347,16 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param str worker_path: Optional path of a manual worker grouping file
         to use for the run.
     :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclusion_list_file below.
-    :param str exclusion_list_file: Path to an exclusion list file, this file
+        option exclude_list below.
+    :param str exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option inclusion_list_file below.
-    :param str inclusion_list_file: Path to a inclusion list file, this file
+        option include_list below.
+    :param str include_list: Path to a inclusion list file, this file
         contains a separate regex on each newline.
     :param str black_regex: DEPRECATED: soon to be replaced by the new
-        option exclusion_regex below.
-    :param str exclusion_regex: Test rejection regex. If a test cases name
+        option exclude_regex below.
+    :param str exclude_regex: Test rejection regex. If a test cases name
         matches on re.search() operation, it will be removed from the final
         test list.
     :param str no_discover: Takes in a single test_id to bypasses test
@@ -392,6 +391,21 @@ def run_command(config='.stestr.conf', repo_type='file',
     if partial:
         warnings.warn('The partial flag is deprecated and has no effect '
                       'anymore')
+    if blacklist_file is not None:
+        warnings.warn("The blacklist-file argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "exclude-list which is functionally equivalent",
+                      DeprecationWarning)
+    if whitelist_file is not None:
+        warnings.warn("The whitelist-file argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "include-list which is functionally equivalent",
+                      DeprecationWarning)
+    if black_regex is not None:
+        warnings.warn("The black-regex argument is deprecated and will be "
+                      "removed in a future release. Instead you should use "
+                      "exclude-regex which is functionally equivalent",
+                      DeprecationWarning)
     try:
         repo = util.get_repo_open(repo_type, repo_url)
     # If a repo is not found, and there a testr config exists just create it
@@ -535,10 +549,9 @@ def run_command(config='.stestr.conf', repo_type='file',
             ids, regexes=filters, group_regex=group_regex, repo_type=repo_type,
             repo_url=repo_url, serial=serial, worker_path=worker_path,
             concurrency=concurrency, blacklist_file=blacklist_file,
-            exclusion_list_file=exclusion_list_file,
-            whitelist_file=whitelist_file,
-            inclusion_list_file=inclusion_list_file, black_regex=black_regex,
-            exclusion_regex=exclusion_regex,
+            exclude_list=exclude_list, whitelist_file=whitelist_file,
+            include_list=include_list, black_regex=black_regex,
+            exclude_regex=exclude_regex,
             top_dir=top_dir, test_path=test_path, randomize=random)
         if isolated:
             result = 0
@@ -553,11 +566,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                     [test_id], filters, group_regex=group_regex,
                     repo_type=repo_type, repo_url=repo_url, serial=serial,
                     worker_path=worker_path, concurrency=concurrency,
-                    blacklist_file=blacklist_file,
-                    exclusion_list_file=exclusion_list_file,
-                    whitelist_file=whitelist_file,
-                    inclusion_list_file=inclusion_list_file,
-                    black_regex=black_regex, exclusion_regex=exclusion_regex,
+                    blacklist_file=blacklist_file, exclude_list=exclude_list,
+                    whitelist_file=whitelist_file, include_list=include_list,
+                    black_regex=black_regex, exclude_regex=exclude_regex,
                     randomize=random, test_path=test_path, top_dir=top_dir)
 
                 run_result = _run_tests(
@@ -596,10 +607,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                 [test_id], group_regex=group_regex, repo_type=repo_type,
                 repo_url=repo_url, serial=serial, worker_path=worker_path,
                 concurrency=concurrency, blacklist_file=blacklist_file,
-                exclusion_list_file=exclusion_list_file,
-                whitelist_file=whitelist_file,
-                inclusion_list_file=inclusion_list_file,
-                black_regex=black_regex, exclusion_regex=exclusion_regex,
+                exclude_list=exclude_list, whitelist_file=whitelist_file,
+                include_list=include_list,
+                black_regex=black_regex, exclude_regex=exclude_regex,
                 randomize=random, test_path=test_path, top_dir=top_dir)
             if not _run_tests(cmd, until_failure):
                 # If the test was filtered, it won't have been run.

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -105,7 +105,9 @@ class Run(command.Command):
                             default=None, dest='blacklist_file',
                             help='DEPRECATED: This option will soon be '
                             'replaced by --exclude-list which is functionally '
-                            'equivalent.')
+                            'equivalent. If this is specified at the same '
+                            'time as --exclude-list, this flag will be '
+                            'ignored and --exclude-list will be used.')
         parser.add_argument('--exclude-list', '-e',
                             default=None, dest='exclude_list',
                             help='Path to an exclusion list file, this file '
@@ -115,7 +117,9 @@ class Run(command.Command):
                             default=None, dest='whitelist_file',
                             help='DEPRECATED: This option will soon be '
                             'replaced by --include-list which is functionally '
-                            'equivalent.')
+                            'equivalent. If this is specified at the same '
+                            'time as --include-list, this flag will be '
+                            'ignored and --include-list will be used.')
         parser.add_argument('--include-list', '-i',
                             default=None, dest='include_list',
                             help='Path to an inclusion list file, this file '
@@ -123,8 +127,10 @@ class Run(command.Command):
         parser.add_argument('--black-regex', '-B', default=None,
                             dest='black_regex',
                             help='DEPRECATED: This option will soon be '
-                            'replaced by --exclude-regex which is '
-                            'functionally equivalent.')
+                            'replaced by --exclude-regex which is functionally'
+                            ' equivalent. If this is specified at the same '
+                            'time as --exclude-regex, this flag will be '
+                            'ignored and --exclude-regex will be used.')
         parser.add_argument('--exclude-regex', '-E', default=None,
                             dest='exclude_regex',
                             help='Test rejection regex. If a test cases name '
@@ -347,15 +353,18 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param str worker_path: Optional path of a manual worker grouping file
         to use for the run.
     :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclude_list below.
+        option exclude_list below. If this is specified at the same time as
+        exclude_list, this flag will be ignored and exclude_list will be used
     :param str exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option include_list below.
+        option include_list below. If this is specified at the same time as
+        include_list, this flag will be ignored and include_list will be used
     :param str include_list: Path to a inclusion list file, this file
         contains a separate regex on each newline.
     :param str black_regex: DEPRECATED: soon to be replaced by the new
-        option exclude_regex below.
+        option exclude_regex below. If this is specified at the same time as
+        exclude_regex, this flag will be ignored and exclude_regex will be used
     :param str exclude_regex: Test rejection regex. If a test cases name
         matches on re.search() operation, it will be removed from the final
         test list.

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -103,12 +103,17 @@ class Run(command.Command):
                             "file to use for the run")
         parser.add_argument('--blacklist-file', '-b',
                             default=None, dest='blacklist_file',
-                            help='Path to a blacklist file, this file '
+                            help='DEPRECATED: This option will soon be '
+                            'replaced by --exclude-list which is functionally '
+                            'equivalent.')
+        parser.add_argument('--exclude-list', '-e',
+                            default=None, dest='exclusion_list_file',
+                            help='Path to an exclusion list file, this file '
                             'contains a separate regex exclude on each '
                             'newline')
         parser.add_argument('--whitelist-file', '-w',
                             default=None, dest='whitelist_file',
-                            help='DEPRECATED: This option will soon be  '
+                            help='DEPRECATED: This option will soon be '
                             'replaced by --include-list which is functionally '
                             'equivalent.')
         parser.add_argument('--include-list', '-i',
@@ -122,7 +127,7 @@ class Run(command.Command):
                             'it will be removed from the final test list. '
                             'Effectively the black-regexp is added to '
                             ' black regexp list, but you do need to edit a '
-                            'file. The black filtering happens after the '
+                            'file. The exclusion filtering happens after the '
                             'initial safe list selection, which by default is '
                             'everything.')
         parser.add_argument('--no-discover', '-n', default=None,
@@ -246,6 +251,7 @@ class Run(command.Command):
             subunit_out=args.subunit, until_failure=args.until_failure,
             analyze_isolation=args.analyze_isolation, isolated=args.isolated,
             worker_path=args.worker_path, blacklist_file=args.blacklist_file,
+            exclusion_list_file=args.exclusion_list_file,
             whitelist_file=args.whitelist_file,
             inclusion_list_file=args.inclusion_list_file,
             black_regex=args.black_regex, no_discover=args.no_discover,
@@ -292,13 +298,13 @@ def run_command(config='.stestr.conf', repo_type='file',
                 failing=False, serial=False, concurrency=0, load_list=None,
                 partial=False, subunit_out=False, until_failure=False,
                 analyze_isolation=False, isolated=False, worker_path=None,
-                blacklist_file=None, whitelist_file=None,
-                inclusion_list_file=None, black_regex=None,
-                no_discover=False, random=False, combine=False, filters=None,
-                pretty_out=True, color=False, stdout=sys.stdout,
-                abbreviate=False, suppress_attachments=False,
-                all_attachments=False, show_binary_attachments=True,
-                pdb=False):
+                blacklist_file=None, exclusion_list_file=None,
+                whitelist_file=None, inclusion_list_file=None,
+                black_regex=None, no_discover=False, random=False,
+                combine=False, filters=None, pretty_out=True, color=False,
+                stdout=sys.stdout, abbreviate=False,
+                suppress_attachments=False, all_attachments=False,
+                show_binary_attachments=True, pdb=False):
     """Function to execute the run command
 
     This function implements the run command. It will run the tests specified
@@ -336,8 +342,10 @@ def run_command(config='.stestr.conf', repo_type='file',
     :param bool isolated: Run each test id in a separate test runner.
     :param str worker_path: Optional path of a manual worker grouping file
         to use for the run.
-    :param str blacklist_file: Path to a blacklist file, this file contains a
-        separate regex exclude on each newline.
+    :param str blacklist_file: DEPRECATED: soon to be replaced by the new
+        option exclusion_list_file below.
+    :param str exclusion_list_file: Path to an exclusion list file, this file
+        contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
         option inclusion_list_file below.
     :param str inclusion_list_file: Path to a inclusion list file, this file
@@ -519,6 +527,7 @@ def run_command(config='.stestr.conf', repo_type='file',
             ids, regexes=filters, group_regex=group_regex, repo_type=repo_type,
             repo_url=repo_url, serial=serial, worker_path=worker_path,
             concurrency=concurrency, blacklist_file=blacklist_file,
+            exclusion_list_file=exclusion_list_file,
             whitelist_file=whitelist_file,
             inclusion_list_file=inclusion_list_file, black_regex=black_regex,
             top_dir=top_dir, test_path=test_path, randomize=random)
@@ -536,6 +545,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                     repo_type=repo_type, repo_url=repo_url, serial=serial,
                     worker_path=worker_path, concurrency=concurrency,
                     blacklist_file=blacklist_file,
+                    exclusion_list_file=exclusion_list_file,
                     whitelist_file=whitelist_file,
                     inclusion_list_file=inclusion_list_file,
                     black_regex=black_regex,
@@ -577,6 +587,7 @@ def run_command(config='.stestr.conf', repo_type='file',
                 [test_id], group_regex=group_regex, repo_type=repo_type,
                 repo_url=repo_url, serial=serial, worker_path=worker_path,
                 concurrency=concurrency, blacklist_file=blacklist_file,
+                exclusion_list_file=exclusion_list_file,
                 whitelist_file=whitelist_file,
                 inclusion_list_file=inclusion_list_file,
                 black_regex=black_regex, randomize=random, test_path=test_path,

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -108,7 +108,12 @@ class Run(command.Command):
                             'newline')
         parser.add_argument('--whitelist-file', '-w',
                             default=None, dest='whitelist_file',
-                            help='Path to a whitelist file, this file '
+                            help='DEPRECATED: This option will soon be  '
+                            'replaced by --include-list which is functionally '
+                            'equivalent.')
+        parser.add_argument('--include-list', '-i',
+                            default=None, dest='inclusion_list_file',
+                            help='Path to an inclusion list file, this file '
                             'contains a separate regex on each newline.')
         parser.add_argument('--black-regex', '-B', default=None,
                             dest='black_regex',
@@ -118,7 +123,7 @@ class Run(command.Command):
                             'Effectively the black-regexp is added to '
                             ' black regexp list, but you do need to edit a '
                             'file. The black filtering happens after the '
-                            'initial white selection, which by default is '
+                            'initial safe list selection, which by default is '
                             'everything.')
         parser.add_argument('--no-discover', '-n', default=None,
                             metavar='TEST_ID',
@@ -241,9 +246,10 @@ class Run(command.Command):
             subunit_out=args.subunit, until_failure=args.until_failure,
             analyze_isolation=args.analyze_isolation, isolated=args.isolated,
             worker_path=args.worker_path, blacklist_file=args.blacklist_file,
-            whitelist_file=args.whitelist_file, black_regex=args.black_regex,
-            no_discover=args.no_discover, random=random,
-            combine=args.combine,
+            whitelist_file=args.whitelist_file,
+            inclusion_list_file=args.inclusion_list_file,
+            black_regex=args.black_regex, no_discover=args.no_discover,
+            random=random, combine=args.combine,
             filters=filters, pretty_out=pretty_out, color=color,
             stdout=stdout, abbreviate=abbreviate,
             suppress_attachments=suppress_attachments,
@@ -286,7 +292,8 @@ def run_command(config='.stestr.conf', repo_type='file',
                 failing=False, serial=False, concurrency=0, load_list=None,
                 partial=False, subunit_out=False, until_failure=False,
                 analyze_isolation=False, isolated=False, worker_path=None,
-                blacklist_file=None, whitelist_file=None, black_regex=None,
+                blacklist_file=None, whitelist_file=None,
+                inclusion_list_file=None, black_regex=None,
                 no_discover=False, random=False, combine=False, filters=None,
                 pretty_out=True, color=False, stdout=sys.stdout,
                 abbreviate=False, suppress_attachments=False,
@@ -331,8 +338,10 @@ def run_command(config='.stestr.conf', repo_type='file',
         to use for the run.
     :param str blacklist_file: Path to a blacklist file, this file contains a
         separate regex exclude on each newline.
-    :param str whitelist_file: Path to a whitelist file, this file contains a
-        separate regex on each newline.
+    :param str whitelist_file: DEPRECATED: soon to be replaced by the new
+        option inclusion_list_file below.
+    :param str inclusion_list_file: Path to a inclusion list file, this file
+        contains a separate regex on each newline.
     :param str black_regex: Test rejection regex. If a test cases name matches
         on re.search() operation, it will be removed from the final test list.
     :param str no_discover: Takes in a single test_id to bypasses test
@@ -510,7 +519,8 @@ def run_command(config='.stestr.conf', repo_type='file',
             ids, regexes=filters, group_regex=group_regex, repo_type=repo_type,
             repo_url=repo_url, serial=serial, worker_path=worker_path,
             concurrency=concurrency, blacklist_file=blacklist_file,
-            whitelist_file=whitelist_file, black_regex=black_regex,
+            whitelist_file=whitelist_file,
+            inclusion_list_file=inclusion_list_file, black_regex=black_regex,
             top_dir=top_dir, test_path=test_path, randomize=random)
         if isolated:
             result = 0
@@ -526,7 +536,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                     repo_type=repo_type, repo_url=repo_url, serial=serial,
                     worker_path=worker_path, concurrency=concurrency,
                     blacklist_file=blacklist_file,
-                    whitelist_file=whitelist_file, black_regex=black_regex,
+                    whitelist_file=whitelist_file,
+                    inclusion_list_file=inclusion_list_file,
+                    black_regex=black_regex,
                     randomize=random, test_path=test_path, top_dir=top_dir)
 
                 run_result = _run_tests(
@@ -565,8 +577,9 @@ def run_command(config='.stestr.conf', repo_type='file',
                 [test_id], group_regex=group_regex, repo_type=repo_type,
                 repo_url=repo_url, serial=serial, worker_path=worker_path,
                 concurrency=concurrency, blacklist_file=blacklist_file,
-                whitelist_file=whitelist_file, black_regex=black_regex,
-                randomize=random, test_path=test_path,
+                whitelist_file=whitelist_file,
+                inclusion_list_file=inclusion_list_file,
+                black_regex=black_regex, randomize=random, test_path=test_path,
                 top_dir=top_dir)
             if not _run_tests(cmd, until_failure):
                 # If the test was filtered, it won't have been run.

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -48,7 +48,8 @@ class TestrConf(object):
                         repo_type='file', repo_url=None,
                         serial=False, worker_path=None,
                         concurrency=0, blacklist_file=None,
-                        whitelist_file=None, black_regex=None,
+                        whitelist_file=None,
+                        inclusion_list_file=None, black_regex=None,
                         randomize=False, parallel_class=None):
         """Get a test_processor.TestProcessorFixture for this config file
 
@@ -85,8 +86,10 @@ class TestrConf(object):
             autodetects your CPU count and uses that.
         :param str blacklist_file: Path to a blacklist file, this file contains
             a separate regex exclude on each newline.
-        :param str whitelist_file: Path to a whitelist file, this file contains
-            a separate regex on each newline.
+        :param str whitelist_file: DEPRECATED: soon to be replaced by the new
+            option inclusion_list_file below.
+        :param str inclusion_list_file: Path to an inclusion list file, this
+            file contains a separate regex on each newline.
         :param str black_regex: Test rejection regex. If a test cases name
             matches on re.search() operation, it will be removed from the final
             test list.
@@ -166,4 +169,5 @@ class TestrConf(object):
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,
             blacklist_file=blacklist_file, black_regex=black_regex,
-            whitelist_file=whitelist_file, randomize=randomize)
+            whitelist_file=whitelist_file,
+            inclusion_list_file=inclusion_list_file, randomize=randomize)

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -50,6 +50,7 @@ class TestrConf(object):
                         concurrency=0, blacklist_file=None,
                         exclusion_list_file=None, whitelist_file=None,
                         inclusion_list_file=None, black_regex=None,
+                        exclusion_regex=None,
                         randomize=False, parallel_class=None):
         """Get a test_processor.TestProcessorFixture for this config file
 
@@ -92,7 +93,9 @@ class TestrConf(object):
             option inclusion_list_file below.
         :param str inclusion_list_file: Path to an inclusion list file, this
             file contains a separate regex on each newline.
-        :param str black_regex: Test rejection regex. If a test cases name
+        :param str black_regex: DEPRECATED: soon to be replaced by the new
+            option exclusion_regex below.
+        :param str exclusion_regex: Test rejection regex. If a test cases name
             matches on re.search() operation, it will be removed from the final
             test list.
         :param bool randomize: Randomize the test order after they are
@@ -171,6 +174,6 @@ class TestrConf(object):
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,
             blacklist_file=blacklist_file,
-            exclusion_list_file=exclusion_list_file,
-            black_regex=black_regex, whitelist_file=whitelist_file,
+            exclusion_list_file=exclusion_list_file, black_regex=black_regex,
+            exclusion_regex=exclusion_regex, whitelist_file=whitelist_file,
             inclusion_list_file=inclusion_list_file, randomize=randomize)

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -48,7 +48,7 @@ class TestrConf(object):
                         repo_type='file', repo_url=None,
                         serial=False, worker_path=None,
                         concurrency=0, blacklist_file=None,
-                        whitelist_file=None,
+                        exclusion_list_file=None, whitelist_file=None,
                         inclusion_list_file=None, black_regex=None,
                         randomize=False, parallel_class=None):
         """Get a test_processor.TestProcessorFixture for this config file
@@ -84,8 +84,10 @@ class TestrConf(object):
             to use for the run.
         :param int concurrency: How many processes to use. The default (0)
             autodetects your CPU count and uses that.
-        :param str blacklist_file: Path to a blacklist file, this file contains
-            a separate regex exclude on each newline.
+        :param str blacklist_file: DEPRECATED: soon to be replaced by the new
+            option exclusion_list_file below.
+        :param str exclusion_list_file: Path to an exclusion list file, this
+            file contains a separate regex exclude on each newline.
         :param str whitelist_file: DEPRECATED: soon to be replaced by the new
             option inclusion_list_file below.
         :param str inclusion_list_file: Path to an inclusion list file, this
@@ -168,6 +170,7 @@ class TestrConf(object):
             test_ids, command, listopt, idoption, repository,
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,
-            blacklist_file=blacklist_file, black_regex=black_regex,
-            whitelist_file=whitelist_file,
+            blacklist_file=blacklist_file,
+            exclusion_list_file=exclusion_list_file,
+            black_regex=black_regex, whitelist_file=whitelist_file,
             inclusion_list_file=inclusion_list_file, randomize=randomize)

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -48,9 +48,9 @@ class TestrConf(object):
                         repo_type='file', repo_url=None,
                         serial=False, worker_path=None,
                         concurrency=0, blacklist_file=None,
-                        exclusion_list_file=None, whitelist_file=None,
-                        inclusion_list_file=None, black_regex=None,
-                        exclusion_regex=None,
+                        exclude_list=None, whitelist_file=None,
+                        include_list=None, black_regex=None,
+                        exclude_regex=None,
                         randomize=False, parallel_class=None):
         """Get a test_processor.TestProcessorFixture for this config file
 
@@ -85,17 +85,17 @@ class TestrConf(object):
             to use for the run.
         :param int concurrency: How many processes to use. The default (0)
             autodetects your CPU count and uses that.
-        :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-            option exclusion_list_file below.
-        :param str exclusion_list_file: Path to an exclusion list file, this
+        :param str blacklist_file: Available now but soon to be replaced by the
+            new option exclude_list below.
+        :param str exclude_list: Path to an exclusion list file, this
             file contains a separate regex exclude on each newline.
-        :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-            option inclusion_list_file below.
-        :param str inclusion_list_file: Path to an inclusion list file, this
+        :param str whitelist_file: Available now but soon to be replaced by the
+            new option include_list below.
+        :param str include_list: Path to an inclusion list file, this
             file contains a separate regex on each newline.
-        :param str black_regex: DEPRECATED: soon to be replaced by the new
-            option exclusion_regex below.
-        :param str exclusion_regex: Test rejection regex. If a test cases name
+        :param str black_regex: Available now but soon to be replaced by the
+            new option exclude_regex below.
+        :param str exclude_regex: Test rejection regex. If a test cases name
             matches on re.search() operation, it will be removed from the final
             test list.
         :param bool randomize: Randomize the test order after they are
@@ -174,6 +174,6 @@ class TestrConf(object):
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,
             blacklist_file=blacklist_file,
-            exclusion_list_file=exclusion_list_file, black_regex=black_regex,
-            exclusion_regex=exclusion_regex, whitelist_file=whitelist_file,
-            inclusion_list_file=inclusion_list_file, randomize=randomize)
+            exclude_list=exclude_list, black_regex=black_regex,
+            exclude_regex=exclude_regex, whitelist_file=whitelist_file,
+            include_list=include_list, randomize=randomize)

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -91,7 +91,7 @@ def _get_regex_from_inclusion_list_file(file_path):
 
 def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
                    regexes=None, black_regex=None, exclusion_list_file=None,
-                   inclusion_list_file=None):
+                   inclusion_list_file=None, exclusion_regex=None):
     """Filters the discovered test cases
 
     :param list test_ids: The set of test_ids to be filtered
@@ -101,9 +101,10 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
         output will contain any test_ids which have a re.search() match for any
         of the regexes in this list. If this is None all test_ids will be
         returned
-    :param str black_regex:
+    :param str black_regex: DEPRECATED: Replaced by exclusion_regex
     :param str exclusion_list_file: The path to an exclusion_list file
     :param str inclusion_list_file: The path to an inclusion_list file
+    :param str exclusion_regex: regex pattern to exclude tests
 
     :return: iterable of strings. The strings are full
         test_ids
@@ -131,7 +132,19 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
     else:
         exclude_data = None
 
-    if black_regex:
+    if exclusion_regex:
+        msg = "Skipped because of regexp provided as a command line argument:"
+        try:
+            record = (re.compile(exclusion_regex), msg, [])
+        except re.error:
+            print("Invalid regex: %s used for exclusion_regex" %
+                  exclusion_regex, file=sys.stderr)
+            sys.exit(5)
+        if exclude_data:
+            exclude_data.append(record)
+        else:
+            exclude_data = [record]
+    elif black_regex:
         msg = "Skipped because of regexp provided as a command line argument:"
         try:
             record = (re.compile(black_regex), msg, [])

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -49,10 +49,10 @@ def filter_tests(filters, test_ids):
     return list(filter(include, test_ids))
 
 
-def black_reader(blacklist_file):
-    with contextlib.closing(open(blacklist_file, 'r')) as black_file:
+def exclusion_reader(exclusion_list_file):
+    with contextlib.closing(open(exclusion_list_file, 'r')) as exclude_file:
         regex_comment_lst = []  # tuple of (regex_compiled, msg, skipped_lst)
-        for line in black_file:
+        for line in exclude_file:
             raw_line = line.strip()
             split_line = raw_line.split('#')
             # Before the # is the regex
@@ -67,7 +67,7 @@ def black_reader(blacklist_file):
             try:
                 regex_comment_lst.append((re.compile(line_regex), comment, []))
             except re.error:
-                print("Invalid regex: %s in provided blacklist file" %
+                print("Invalid regex: %s in provided exclusion list file" %
                       line_regex, file=sys.stderr)
                 sys.exit(5)
     return regex_comment_lst
@@ -90,18 +90,20 @@ def _get_regex_from_inclusion_list_file(file_path):
 
 
 def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
-                   regexes=None, black_regex=None, inclusion_list_file=None):
+                   regexes=None, black_regex=None, exclusion_list_file=None,
+                   inclusion_list_file=None):
     """Filters the discovered test cases
 
     :param list test_ids: The set of test_ids to be filtered
-    :param str blacklist_file: The path to a blacklist file
+    :param str blacklist_file: DEPRECATED: Replaced by exclusion_list_file
     :param str whitelist_file: DEPRECATED: Replaced by inclusion_list_file
-    :param str inclusion_list_file: The path to a inclusion_list file
     :param list regexes: A list of regex filters to apply to the test_ids. The
         output will contain any test_ids which have a re.search() match for any
         of the regexes in this list. If this is None all test_ids will be
         returned
     :param str black_regex:
+    :param str exclusion_list_file: The path to an exclusion_list file
+    :param str inclusion_list_file: The path to an inclusion_list file
 
     :return: iterable of strings. The strings are full
         test_ids
@@ -122,10 +124,12 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
     elif regexes and safe_re:
         regexes += safe_re
 
-    if blacklist_file:
-        black_data = black_reader(blacklist_file)
+    if exclusion_list_file:
+        exclude_data = exclusion_reader(exclusion_list_file)
+    elif blacklist_file:
+        exclude_data = exclusion_reader(blacklist_file)
     else:
-        black_data = None
+        exclude_data = None
 
     if black_regex:
         msg = "Skipped because of regexp provided as a command line argument:"
@@ -135,20 +139,20 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
             print("Invalid regex: %s used for black_regex" % black_regex,
                   file=sys.stderr)
             sys.exit(5)
-        if black_data:
-            black_data.append(record)
+        if exclude_data:
+            exclude_data.append(record)
         else:
-            black_data = [record]
+            exclude_data = [record]
 
     list_of_test_cases = filter_tests(regexes, test_ids)
     set_of_test_cases = set(list_of_test_cases)
 
-    if not black_data:
+    if not exclude_data:
         return set_of_test_cases
 
     # NOTE(afazekas): We might use a faster logic when the
     # print option is not requested
-    for (rex, msg, s_list) in black_data:
+    for (rex, msg, s_list) in exclude_data:
         for test_case in list_of_test_cases:
             if rex.search(test_case):
                 # NOTE(mtreinish): In the case of overlapping regex the test

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -49,8 +49,8 @@ def filter_tests(filters, test_ids):
     return list(filter(include, test_ids))
 
 
-def exclusion_reader(exclusion_list_file):
-    with contextlib.closing(open(exclusion_list_file, 'r')) as exclude_file:
+def exclusion_reader(exclude_list):
+    with contextlib.closing(open(exclude_list, 'r')) as exclude_file:
         regex_comment_lst = []  # tuple of (regex_compiled, msg, skipped_lst)
         for line in exclude_file:
             raw_line = line.strip()
@@ -73,7 +73,7 @@ def exclusion_reader(exclusion_list_file):
     return regex_comment_lst
 
 
-def _get_regex_from_inclusion_list_file(file_path):
+def _get_regex_from_include_list(file_path):
     lines = []
     for line in open(file_path).read().splitlines():
         split_line = line.strip().split('#')
@@ -90,21 +90,21 @@ def _get_regex_from_inclusion_list_file(file_path):
 
 
 def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
-                   regexes=None, black_regex=None, exclusion_list_file=None,
-                   inclusion_list_file=None, exclusion_regex=None):
+                   regexes=None, black_regex=None, exclude_list=None,
+                   include_list=None, exclude_regex=None):
     """Filters the discovered test cases
 
     :param list test_ids: The set of test_ids to be filtered
-    :param str blacklist_file: DEPRECATED: Replaced by exclusion_list_file
-    :param str whitelist_file: DEPRECATED: Replaced by inclusion_list_file
+    :param str blacklist_file: Soon to be replaced by exclude_list
+    :param str whitelist_file: Soon to be replaced by include_list
     :param list regexes: A list of regex filters to apply to the test_ids. The
         output will contain any test_ids which have a re.search() match for any
         of the regexes in this list. If this is None all test_ids will be
         returned
-    :param str black_regex: DEPRECATED: Replaced by exclusion_regex
-    :param str exclusion_list_file: The path to an exclusion_list file
-    :param str inclusion_list_file: The path to an inclusion_list file
-    :param str exclusion_regex: regex pattern to exclude tests
+    :param str black_regex: Soon to be replaced by exclude_regex
+    :param str exclude_list: The path to an exclusion_list file
+    :param str include_list: The path to an inclusion_list file
+    :param str exclude_regex: regex pattern to exclude tests
 
     :return: iterable of strings. The strings are full
         test_ids
@@ -115,30 +115,30 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
         regexes = None  # handle the other false things
 
     safe_re = None
-    if inclusion_list_file:
-        safe_re = _get_regex_from_inclusion_list_file(inclusion_list_file)
+    if include_list:
+        safe_re = _get_regex_from_include_list(include_list)
     elif whitelist_file:
-        safe_re = _get_regex_from_inclusion_list_file(whitelist_file)
+        safe_re = _get_regex_from_include_list(whitelist_file)
 
     if not regexes and safe_re:
         regexes = safe_re
     elif regexes and safe_re:
         regexes += safe_re
 
-    if exclusion_list_file:
-        exclude_data = exclusion_reader(exclusion_list_file)
+    if exclude_list:
+        exclude_data = exclusion_reader(exclude_list)
     elif blacklist_file:
         exclude_data = exclusion_reader(blacklist_file)
     else:
         exclude_data = None
 
-    if exclusion_regex:
+    if exclude_regex:
         msg = "Skipped because of regexp provided as a command line argument:"
         try:
-            record = (re.compile(exclusion_regex), msg, [])
+            record = (re.compile(exclude_regex), msg, [])
         except re.error:
-            print("Invalid regex: %s used for exclusion_regex" %
-                  exclusion_regex, file=sys.stderr)
+            print("Invalid regex: %s used for exclude_regex" %
+                  exclude_regex, file=sys.stderr)
             sys.exit(5)
         if exclude_data:
             exclude_data.append(record)

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -70,8 +70,10 @@ class TestProcessorFixture(fixtures.Fixture):
         autodetects your CPU count and uses that.
     :param path blacklist_file: Path to a blacklist file, this file contains a
         separate regex exclude on each newline.
-    :param path whitelist_file: Path to a whitelist file, this file contains a
-         separate regex on each newline.
+    :param str whitelist_file: DEPRECATED: soon to be replaced by the new
+        option inclusion_list_file below.
+    :param path inclusion_list_file: Path to an inclusion list file, this file
+         contains a separate regex on each newline.
     :param boolean randomize: Randomize the test order after they are
         partitioned into separate workers
     """
@@ -80,7 +82,8 @@ class TestProcessorFixture(fixtures.Fixture):
                  repository, parallel=True, listpath=None,
                  test_filters=None, group_callback=None, serial=False,
                  worker_path=None, concurrency=0, blacklist_file=None,
-                 black_regex=None, whitelist_file=None, randomize=False):
+                 black_regex=None, whitelist_file=None,
+                 inclusion_list_file=None, randomize=False):
         """Create a TestProcessorFixture."""
 
         self.test_ids = test_ids
@@ -99,6 +102,7 @@ class TestProcessorFixture(fixtures.Fixture):
         self.concurrency_value = concurrency
         self.blacklist_file = blacklist_file
         self.whitelist_file = whitelist_file
+        self.inclusion_list_file = inclusion_list_file
         self.black_regex = black_regex
         self.randomize = randomize
 
@@ -116,7 +120,8 @@ class TestProcessorFixture(fixtures.Fixture):
         self.list_cmd = re.sub(variable_regex, list_subst, cmd)
         nonparallel = not self.parallel
         selection_logic = (self.test_filters or self.blacklist_file or
-                           self.whitelist_file or self.black_regex)
+                           self.whitelist_file or self.inclusion_list_file or
+                           self.black_regex)
         if nonparallel:
             self.concurrency = 1
         else:
@@ -144,6 +149,7 @@ class TestProcessorFixture(fixtures.Fixture):
             self.test_ids = selection.construct_list(
                 self.test_ids, blacklist_file=self.blacklist_file,
                 whitelist_file=self.whitelist_file,
+                inclusion_list_file=self.inclusion_list_file,
                 regexes=self.test_filters,
                 black_regex=self.black_regex)
             name = self.make_listfile()

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -68,8 +68,10 @@ class TestProcessorFixture(fixtures.Fixture):
         to use for the run
     :param int concurrency: How many processes to use. The default (0)
         autodetects your CPU count and uses that.
-    :param path blacklist_file: Path to a blacklist file, this file contains a
-        separate regex exclude on each newline.
+    :param path blacklist_file: DEPRECATED: soon to be replaced by the new
+        option exclusion_list_file below.
+    :param path exclusion_list_file: Path to an exclusion list file, this file
+        contains a separate regex exclude on each newline.
     :param str whitelist_file: DEPRECATED: soon to be replaced by the new
         option inclusion_list_file below.
     :param path inclusion_list_file: Path to an inclusion list file, this file
@@ -82,8 +84,9 @@ class TestProcessorFixture(fixtures.Fixture):
                  repository, parallel=True, listpath=None,
                  test_filters=None, group_callback=None, serial=False,
                  worker_path=None, concurrency=0, blacklist_file=None,
-                 black_regex=None, whitelist_file=None,
-                 inclusion_list_file=None, randomize=False):
+                 exclusion_list_file=None, black_regex=None,
+                 whitelist_file=None, inclusion_list_file=None,
+                 randomize=False):
         """Create a TestProcessorFixture."""
 
         self.test_ids = test_ids
@@ -101,6 +104,7 @@ class TestProcessorFixture(fixtures.Fixture):
         self.worker_path = worker_path
         self.concurrency_value = concurrency
         self.blacklist_file = blacklist_file
+        self.exclusion_list_file = exclusion_list_file
         self.whitelist_file = whitelist_file
         self.inclusion_list_file = inclusion_list_file
         self.black_regex = black_regex
@@ -120,8 +124,8 @@ class TestProcessorFixture(fixtures.Fixture):
         self.list_cmd = re.sub(variable_regex, list_subst, cmd)
         nonparallel = not self.parallel
         selection_logic = (self.test_filters or self.blacklist_file or
-                           self.whitelist_file or self.inclusion_list_file or
-                           self.black_regex)
+                           self.exclusion_list_file or self.whitelist_file or
+                           self.inclusion_list_file or self.black_regex)
         if nonparallel:
             self.concurrency = 1
         else:
@@ -148,6 +152,7 @@ class TestProcessorFixture(fixtures.Fixture):
         else:
             self.test_ids = selection.construct_list(
                 self.test_ids, blacklist_file=self.blacklist_file,
+                exclusion_list_file=self.exclusion_list_file,
                 whitelist_file=self.whitelist_file,
                 inclusion_list_file=self.inclusion_list_file,
                 regexes=self.test_filters,

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -68,13 +68,13 @@ class TestProcessorFixture(fixtures.Fixture):
         to use for the run
     :param int concurrency: How many processes to use. The default (0)
         autodetects your CPU count and uses that.
-    :param path blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclusion_list_file below.
-    :param path exclusion_list_file: Path to an exclusion list file, this file
+    :param path blacklist_file: Available now but soon to be replaced by the
+        new option exclude_list below.
+    :param path exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
-    :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option inclusion_list_file below.
-    :param path inclusion_list_file: Path to an inclusion list file, this file
+    :param str whitelist_file: Available now but soon to be replaced by the
+        new option include_list below.
+    :param path include_list: Path to an inclusion list file, this file
          contains a separate regex on each newline.
     :param boolean randomize: Randomize the test order after they are
         partitioned into separate workers
@@ -84,9 +84,9 @@ class TestProcessorFixture(fixtures.Fixture):
                  repository, parallel=True, listpath=None,
                  test_filters=None, group_callback=None, serial=False,
                  worker_path=None, concurrency=0, blacklist_file=None,
-                 exclusion_list_file=None, black_regex=None,
-                 exclusion_regex=None, whitelist_file=None,
-                 inclusion_list_file=None, randomize=False):
+                 exclude_list=None, black_regex=None,
+                 exclude_regex=None, whitelist_file=None,
+                 include_list=None, randomize=False):
         """Create a TestProcessorFixture."""
 
         self.test_ids = test_ids
@@ -104,11 +104,11 @@ class TestProcessorFixture(fixtures.Fixture):
         self.worker_path = worker_path
         self.concurrency_value = concurrency
         self.blacklist_file = blacklist_file
-        self.exclusion_list_file = exclusion_list_file
+        self.exclude_list = exclude_list
         self.whitelist_file = whitelist_file
-        self.inclusion_list_file = inclusion_list_file
+        self.include_list = include_list
         self.black_regex = black_regex
-        self.exclusion_regex = exclusion_regex
+        self.exclude_regex = exclude_regex
         self.randomize = randomize
 
     def setUp(self):
@@ -125,9 +125,9 @@ class TestProcessorFixture(fixtures.Fixture):
         self.list_cmd = re.sub(variable_regex, list_subst, cmd)
         nonparallel = not self.parallel
         selection_logic = (self.test_filters or self.blacklist_file or
-                           self.exclusion_list_file or self.whitelist_file or
-                           self.inclusion_list_file or self.black_regex or
-                           self.exclusion_regex)
+                           self.exclude_list or self.whitelist_file or
+                           self.include_list or self.black_regex or
+                           self.exclude_regex)
         if nonparallel:
             self.concurrency = 1
         else:
@@ -154,12 +154,12 @@ class TestProcessorFixture(fixtures.Fixture):
         else:
             self.test_ids = selection.construct_list(
                 self.test_ids, blacklist_file=self.blacklist_file,
-                exclusion_list_file=self.exclusion_list_file,
+                exclude_list=self.exclude_list,
                 whitelist_file=self.whitelist_file,
-                inclusion_list_file=self.inclusion_list_file,
+                include_list=self.include_list,
                 regexes=self.test_filters,
                 black_regex=self.black_regex,
-                exclusion_regex=self.exclusion_regex)
+                exclude_regex=self.exclude_regex)
             name = self.make_listfile()
             variables['IDFILE'] = name
             idlist = ' '.join(self.test_ids)

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -85,8 +85,8 @@ class TestProcessorFixture(fixtures.Fixture):
                  test_filters=None, group_callback=None, serial=False,
                  worker_path=None, concurrency=0, blacklist_file=None,
                  exclusion_list_file=None, black_regex=None,
-                 whitelist_file=None, inclusion_list_file=None,
-                 randomize=False):
+                 exclusion_regex=None, whitelist_file=None,
+                 inclusion_list_file=None, randomize=False):
         """Create a TestProcessorFixture."""
 
         self.test_ids = test_ids
@@ -108,6 +108,7 @@ class TestProcessorFixture(fixtures.Fixture):
         self.whitelist_file = whitelist_file
         self.inclusion_list_file = inclusion_list_file
         self.black_regex = black_regex
+        self.exclusion_regex = exclusion_regex
         self.randomize = randomize
 
     def setUp(self):
@@ -125,7 +126,8 @@ class TestProcessorFixture(fixtures.Fixture):
         nonparallel = not self.parallel
         selection_logic = (self.test_filters or self.blacklist_file or
                            self.exclusion_list_file or self.whitelist_file or
-                           self.inclusion_list_file or self.black_regex)
+                           self.inclusion_list_file or self.black_regex or
+                           self.exclusion_regex)
         if nonparallel:
             self.concurrency = 1
         else:
@@ -156,7 +158,8 @@ class TestProcessorFixture(fixtures.Fixture):
                 whitelist_file=self.whitelist_file,
                 inclusion_list_file=self.inclusion_list_file,
                 regexes=self.test_filters,
-                black_regex=self.black_regex)
+                black_regex=self.black_regex,
+                exclusion_regex=self.exclusion_regex)
             name = self.make_listfile()
             variables['IDFILE'] = name
             idlist = ' '.join(self.test_ids)

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -61,6 +61,7 @@ class TestTestrConf(base.TestCase):
         mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
             mock_get_repo_open.return_value, black_regex=None,
+            exclusion_regex=None,
             blacklist_file=None, exclusion_list_file=None, concurrency=0,
             group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -61,7 +61,7 @@ class TestTestrConf(base.TestCase):
         mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
             mock_get_repo_open.return_value, black_regex=None,
-            blacklist_file=None, concurrency=0,
+            blacklist_file=None, exclusion_list_file=None, concurrency=0,
             group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,
             whitelist_file=None, inclusion_list_file=None, worker_path=None)

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -61,11 +61,11 @@ class TestTestrConf(base.TestCase):
         mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
             mock_get_repo_open.return_value, black_regex=None,
-            exclusion_regex=None,
-            blacklist_file=None, exclusion_list_file=None, concurrency=0,
+            exclude_regex=None,
+            blacklist_file=None, exclude_list=None, concurrency=0,
             group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,
-            whitelist_file=None, inclusion_list_file=None, worker_path=None)
+            whitelist_file=None, include_list=None, worker_path=None)
 
     @mock.patch.object(config_file, 'sys')
     def _check_get_run_command_exception(self, mock_sys, platform='win32',

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -64,7 +64,7 @@ class TestTestrConf(base.TestCase):
             blacklist_file=None, concurrency=0,
             group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,
-            whitelist_file=None, worker_path=None)
+            whitelist_file=None, inclusion_list_file=None, worker_path=None)
 
     @mock.patch.object(config_file, 'sys')
     def _check_get_run_command_exception(self, mock_sys, platform='win32',

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -141,6 +141,14 @@ class TestReturnCodes(base.TestCase):
         cmd = 'stestr run --blacklist-file %s' % path
         self.assertRunExit(cmd, 0)
 
+    def test_parallel_exclusion_list(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as exclusion_list:
+            exclusion_list.write('fail')
+        cmd = 'stestr run --exclude-list %s' % path
+        self.assertRunExit(cmd, 0)
+
     def test_parallel_whitelist(self):
         fd, path = tempfile.mkstemp()
         self.addCleanup(os.remove, path)
@@ -169,6 +177,14 @@ class TestReturnCodes(base.TestCase):
         with os.fdopen(fd, 'w') as blacklist:
             blacklist.write('fail')
         cmd = 'stestr run --serial --blacklist-file %s' % path
+        self.assertRunExit(cmd, 0)
+
+    def test_serial_exclusion_list(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as exclusion_list:
+            exclusion_list.write('fail')
+        cmd = 'stestr run --serial --exclude-list %s' % path
         self.assertRunExit(cmd, 0)
 
     def test_serial_whitelist(self):

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -149,6 +149,14 @@ class TestReturnCodes(base.TestCase):
         cmd = 'stestr run --whitelist-file %s' % path
         self.assertRunExit(cmd, 0)
 
+    def test_parallel_inclusion_list(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as inclusion_list:
+            inclusion_list.write('passing')
+        cmd = 'stestr run --include-list %s' % path
+        self.assertRunExit(cmd, 0)
+
     def test_serial_passing(self):
         self.assertRunExit('stestr run --serial passing', 0)
 
@@ -169,6 +177,14 @@ class TestReturnCodes(base.TestCase):
         with os.fdopen(fd, 'w') as whitelist:
             whitelist.write('passing')
         cmd = 'stestr run --serial --whitelist-file %s' % path
+        self.assertRunExit(cmd, 0)
+
+    def test_serial_inclusion_list(self):
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(os.remove, path)
+        with os.fdopen(fd, 'w') as inclusion_list:
+            inclusion_list.write('passing')
+        cmd = 'stestr run --serial --include-list %s' % path
         self.assertRunExit(cmd, 0)
 
     def test_serial_subunit_passing(self):

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -204,8 +204,8 @@ class TestConstructList(base.TestCase):
         whitelist_file.close()
 
         result = selection.construct_list(test_lists,
-                                          include_list = 'include_file.txt',
-                                          whitelist_file = 'whitelist_file.txt')
+                                          include_list='include_file.txt',
+                                          whitelist_file='whitelist_file.txt')
         self.assertEqual({'fake_test1[tg]', 'fake_test2[tg]'}, set(result))
         # Cleanup
         os.remove('include_file.txt')

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import io
+import os
 import re
 from unittest import mock
 

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -99,12 +99,25 @@ class TestConstructList(base.TestCase):
         result = selection.construct_list(test_lists, black_regex='foo')
         self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
 
+    def test_simple_exclusion_re(self):
+        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
+        result = selection.construct_list(test_lists, exclusion_regex='foo')
+        self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
+
     def test_invalid_black_re(self):
         test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
         invalid_regex = "fake_regex_with_bad_part[The-BAD-part]"
         with mock.patch('sys.exit', side_effect=ImportError) as exit_mock:
             self.assertRaises(ImportError, selection.construct_list,
                               test_lists, black_regex=invalid_regex)
+            exit_mock.assert_called_once_with(5)
+
+    def test_invalid_exclusion_re(self):
+        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
+        invalid_regex = "fake_regex_with_bad_part[The-BAD-part]"
+        with mock.patch('sys.exit', side_effect=ImportError) as exit_mock:
+            self.assertRaises(ImportError, selection.construct_list,
+                              test_lists, exclusion_regex=invalid_regex)
             exit_mock.assert_called_once_with(5)
 
     def test_blacklist(self):


### PR DESCRIPTION
Added the new option while posting a Deprecation Warning for the old one.
The old option will be supported for now but it is soon to be retired...
So for now, both options are equally usable and will have the same effect.

Tests relying on the old option are kept intact, will be removed only when
the option itself is removed. New tests are added to verify that the same
behaviour is afforded if the new option is used also.

Closes #296 