### PR TITLE
Add python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36
     - os: linux
+      python: 3.9
+      env: TOXENV=py39
+    - os: linux
       python: 3.8
       env: TOXENV=py38
     - os: linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -48,6 +50,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
 project_urls =


### PR DESCRIPTION
This commit adds Python 3.9 support to stestr. It adds Python 3.9 as
supported python version in the trove classifiers for the package
metadata and adds CI jobs that test stestr on python 3.9.