### PR TITLE
Update python syntax to latest

### DIFF
--- a/stestr/bisect_tests.py
+++ b/stestr/bisect_tests.py
@@ -17,12 +17,12 @@ import testtools
 from stestr import output
 
 
-class IsolationAnalyzer(object):
+class IsolationAnalyzer:
 
     def __init__(self, latest_run, conf, run_func, repo, test_path=None,
                  top_dir=None, group_regex=None, repo_type='file',
                  repo_url=None, serial=False, concurrency=0):
-        super(IsolationAnalyzer, self).__init__()
+        super().__init__()
         self._worker_to_test = None
         self._test_to_worker = None
         self.latest_run = latest_run

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -22,7 +22,7 @@ __version__ = version.version_info.version_string_with_vcs()
 class StestrCLI(app.App):
 
     def __init__(self):
-        super(StestrCLI, self).__init__(
+        super().__init__(
             description="A parallel Python test runner built around subunit",
             version=__version__,
             command_manager=commandmanager.CommandManager('stestr.cm'),
@@ -45,9 +45,8 @@ class StestrCLI(app.App):
             self.LOG.debug('got an error: %s', err)
 
     def build_option_parser(self, description, version, argparse_kwargs=None):
-        parser = super(StestrCLI,
-                       self).build_option_parser(description, version,
-                                                 argparse_kwargs)
+        parser = super().build_option_parser(description, version,
+                                             argparse_kwargs)
         parser = self._set_common_opts(parser)
         return parser
 

--- a/stestr/colorizer.py
+++ b/stestr/colorizer.py
@@ -37,7 +37,7 @@
 import sys
 
 
-class AnsiColorizer(object):
+class AnsiColorizer:
     """A colorizer is an object that loosely wraps around a stream
 
     allowing callers to write text to the stream in a particular color.
@@ -85,7 +85,7 @@ class AnsiColorizer(object):
         self.stream.write('\x1b[{};1m{}\x1b[0m'.format(color, text))
 
 
-class NullColorizer(object):
+class NullColorizer:
     """See _AnsiColorizer docstring."""
     def __init__(self, stream):
         self.stream = stream

--- a/stestr/commands/failing.py
+++ b/stestr/commands/failing.py
@@ -38,7 +38,7 @@ class Failing(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(Failing, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument(
             "--subunit", action="store_true",
             default=False, help="Show output as a subunit stream.")

--- a/stestr/commands/last.py
+++ b/stestr/commands/last.py
@@ -39,7 +39,7 @@ class Last(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(Last, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument(
             "--subunit", action="store_true",
             default=False, help="Show output as a subunit stream.")

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -30,7 +30,7 @@ class List(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(List, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument("filters", nargs="*", default=None,
                             help="A list of string regex filters to initially "
                             "apply on the test list. Tests that match any of "

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -47,7 +47,7 @@ class Load(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(Load, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument("files", nargs="*", default=False,
                             help="The subunit v2 stream files to load into the"
                             " repository")

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -61,7 +61,7 @@ class Run(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(Run, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument("filters", nargs="*", default=None,
                             help="A list of string regex filters to initially "
                             "apply on the test list. Tests that match any of "

--- a/stestr/commands/slowest.py
+++ b/stestr/commands/slowest.py
@@ -29,7 +29,7 @@ class Slowest(command.Command):
     """
 
     def get_parser(self, prog_name):
-        parser = super(Slowest, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser.add_argument(
             "--all", action="store_true",
             default=False, help="Show timing for all tests.")

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -20,7 +20,7 @@ from stestr.repository import util
 from stestr import test_processor
 
 
-class TestrConf(object):
+class TestrConf:
     """Create a TestrConf object to represent a specified config file
 
     This class is used to represent an stestr config file. It

--- a/stestr/output.py
+++ b/stestr/output.py
@@ -151,7 +151,7 @@ def output_stream(stream, output=sys.stdout):
     _binary_stdout.flush()
 
 
-class ReturnCodeToSubunit(object):
+class ReturnCodeToSubunit:
     """Converts a process return code to a subunit error on the process stdout.
 
     The ReturnCodeToSubunit object behaves as a read-only stream, supplying

--- a/stestr/repository/abstract.py
+++ b/stestr/repository/abstract.py
@@ -29,7 +29,7 @@ the initialize function in the appropriate repository module.
 from testtools import StreamToDict
 
 
-class AbstractRepositoryFactory(object):
+class AbstractRepositoryFactory:
     """Interface for making or opening repositories."""
 
     def initialise(self, url):
@@ -47,7 +47,7 @@ class AbstractRepositoryFactory(object):
         raise NotImplementedError(self.open)
 
 
-class AbstractRepository(object):
+class AbstractRepository:
     """The base class for Repository implementations.
 
     There are no interesting attributes or methods as yet.
@@ -165,7 +165,7 @@ class AbstractRepository(object):
         raise NotImplementedError(self.find_metadata)
 
 
-class AbstractTestRun(object):
+class AbstractTestRun:
     """A test run that has been stored in a repository.
 
     Should implement the StreamResult protocol as well

--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -58,8 +58,8 @@ class RepositoryFactory(repository.AbstractRepositoryFactory):
         path = os.path.expanduser(url)
         base = os.path.join(path, '.stestr')
         try:
-            stream = open(os.path.join(base, 'format'), 'rt')
-        except (IOError, OSError) as e:
+            stream = open(os.path.join(base, 'format'))
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 raise repository.RepositoryNotFound(url)
             raise
@@ -94,7 +94,7 @@ class Repository(repository.AbstractRepository):
         return value
 
     def _next_stream(self):
-        with open(os.path.join(self.base, 'next-stream'), 'rt') as fp:
+        with open(os.path.join(self.base, 'next-stream')) as fp:
             next_content = fp.read()
         try:
             return int(next_content)
@@ -114,7 +114,7 @@ class Repository(repository.AbstractRepository):
         try:
             with open(os.path.join(self.base, "failing"), 'rb') as fp:
                 run_subunit_content = fp.read()
-        except IOError:
+        except OSError:
             err = sys.exc_info()[1]
             if err.errno == errno.ENOENT:
                 run_subunit_content = _b('')
@@ -134,7 +134,7 @@ class Repository(repository.AbstractRepository):
         try:
             with open(os.path.join(self.base, str(run_id)), 'rb') as fp:
                 run_subunit_content = fp.read()
-        except IOError as e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 raise KeyError("No such run.")
             else:
@@ -243,7 +243,7 @@ class _DiskRun(repository.AbstractTestRun):
         return self._metadata
 
 
-class _SafeInserter(object):
+class _SafeInserter:
 
     def __init__(self, repository, partial=False, run_id=None, metadata=None):
         # XXX: Perhaps should factor into a decorator and use an unaltered
@@ -342,7 +342,7 @@ class _Inserter(_SafeInserter):
             return self._run_id
 
     def stopTestRun(self):
-        super(_Inserter, self).stopTestRun()
+        super().stopTestRun()
         # XXX: locking (other inserts may happen while we update the failing
         # file).
         # Combine failing + this run : strip passed tests, add failures.

--- a/stestr/repository/sql.py
+++ b/stestr/repository/sql.py
@@ -11,7 +11,6 @@
 # under the License.
 
 """Persistent storage of test results."""
-from __future__ import print_function
 
 import datetime
 import io
@@ -91,7 +90,7 @@ class Repository(repository.AbstractRepository):
 
     # TODO(mtreinish): We need to add a subunit2sql api to get the count
     def count(self):
-        super(Repository, self).count()
+        super().count()
 
     def _get_latest_run(self):
         session = self.session_factory()

--- a/stestr/results.py
+++ b/stestr/results.py
@@ -24,10 +24,10 @@ def wasSuccessful(summary):
 class SummarizingResult(testtools.StreamSummary):
 
     def __init__(self):
-        super(SummarizingResult, self).__init__()
+        super().__init__()
 
     def startTestRun(self):
-        super(SummarizingResult, self).startTestRun()
+        super().startTestRun()
         self._first_time = None
         self._last_time = None
 
@@ -41,7 +41,7 @@ class SummarizingResult(testtools.StreamSummary):
                 self._first_time = timestamp
             if timestamp > self._last_time:
                 self._last_time = timestamp
-        super(SummarizingResult, self).status(*args, **kwargs)
+        super().status(*args, **kwargs)
 
     def get_num_failures(self):
         return len(self.failures) + len(self.errors)
@@ -84,7 +84,7 @@ class CLITestResult(testtools.StreamResult):
         :param stream: The stream to use for result
         :param previous_run: The CLITestResult for the previous run
         """
-        super(CLITestResult, self).__init__()
+        super().__init__()
         self._previous_run = previous_run
         self._summary = SummarizingResult()
         self.stream = testtools.compat.unicode_output_stream(stream)
@@ -107,13 +107,13 @@ class CLITestResult(testtools.StreamResult):
             ]))
 
     def status(self, **kwargs):
-        super(CLITestResult, self).status(**kwargs)
+        super().status(**kwargs)
         self._summary.status(**kwargs)
         test_status = kwargs.get('test_status')
         test_tags = kwargs.get('test_tags')
         if test_status == 'fail':
             self.stream.write(
-                self._format_error(str('FAIL'),
+                self._format_error('FAIL',
                                    *(self._summary.errors[-1]),
                                    test_tags=test_tags))
         if test_status not in self.filterable_states:
@@ -161,11 +161,11 @@ class CLITestResult(testtools.StreamResult):
             time, time_delta, values, output=self.stream)
 
     def startTestRun(self):
-        super(CLITestResult, self).startTestRun()
+        super().startTestRun()
         self._summary.startTestRun()
 
     def stopTestRun(self):
-        super(CLITestResult, self).stopTestRun()
+        super().stopTestRun()
         run_id = self.get_id()
         self._summary.stopTestRun()
         self._output_summary(run_id)

--- a/stestr/scheduler.py
+++ b/stestr/scheduler.py
@@ -157,7 +157,7 @@ def generate_worker_partitions(ids, worker_path, repository=None,
 
     :returns: A list where each element is a distinct subset of test_ids.
     """
-    with open(worker_path, 'r') as worker_file:
+    with open(worker_path) as worker_file:
         workers_desc = yaml.safe_load(worker_file.read())
     worker_groups = []
     for worker in workers_desc:

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -9,7 +9,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
 
 import contextlib
 import re
@@ -50,7 +49,7 @@ def filter_tests(filters, test_ids):
 
 
 def exclusion_reader(exclude_list):
-    with contextlib.closing(open(exclude_list, 'r')) as exclude_file:
+    with contextlib.closing(open(exclude_list)) as exclude_file:
         regex_comment_lst = []  # tuple of (regex_compiled, msg, skipped_lst)
         for line in exclude_file:
             raw_line = line.strip()

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -15,9 +15,6 @@
 # under the License.
 
 """Trace a subunit stream in reasonable detail and high accuracy."""
-from __future__ import absolute_import
-from __future__ import print_function
-
 import argparse
 import functools
 import os

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -112,7 +112,7 @@ class TestProcessorFixture(fixtures.Fixture):
         self.randomize = randomize
 
     def setUp(self):
-        super(TestProcessorFixture, self).setUp()
+        super().setUp()
         variable_regex = r'\$(IDOPTION|IDFILE|IDLIST|LISTOPT)'
         variables = {}
         list_variables = {'LISTOPT': self.listopt}

--- a/stestr/testlist.py
+++ b/stestr/testlist.py
@@ -46,7 +46,7 @@ def parse_enumeration(enumeration_bytes):
 
 def _v1(list_bytes):
     return [id.strip() for id in list_bytes.decode('utf8').split(
-        str('\n')) if id.strip()]
+        '\n') if id.strip()]
 
 
 def _v2(list_bytes):

--- a/stestr/tests/base.py
+++ b/stestr/tests/base.py
@@ -17,7 +17,7 @@ import testtools
 class TestCase(testtools.TestCase):
 
     def setUp(self):
-        super(TestCase, self).setUp()
+        super().setUp()
         stdout = self.useFixture(fixtures.StringStream('stdout')).stream
         self.useFixture(fixtures.MonkeyPatch('sys.stdout', stdout))
         stderr = self.useFixture(fixtures.StringStream('stderr')).stream

--- a/stestr/tests/repository/test_file.py
+++ b/stestr/tests/repository/test_file.py
@@ -27,12 +27,12 @@ from stestr.tests import base
 class FileRepositoryFixture(fixtures.Fixture):
 
     def __init__(self, path=None, initialise=True):
-        super(FileRepositoryFixture, self).__init__()
+        super().__init__()
         self.path = path
         self.initialise = initialise
 
     def setUp(self):
-        super(FileRepositoryFixture, self).setUp()
+        super().setUp()
         if self.path and os.path.isdir(self.path):
             self.tempdir = self.path
         else:
@@ -46,7 +46,7 @@ class HomeDirTempDir(fixtures.Fixture):
     """Creates a temporary directory in ~."""
 
     def setUp(self):
-        super(HomeDirTempDir, self).setUp()
+        super().setUp()
         home_dir = os.path.expanduser('~')
         self.temp_dir = tempfile.mkdtemp(dir=home_dir)
         self.addCleanup(shutil.rmtree, self.temp_dir)
@@ -56,7 +56,7 @@ class HomeDirTempDir(fixtures.Fixture):
 class TestFileRepository(base.TestCase):
 
     def setUp(self):
-        super(TestFileRepository, self).setUp()
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -65,10 +65,10 @@ class TestFileRepository(base.TestCase):
         base = os.path.join(self.tempdir, '.stestr')
         self.assertTrue(os.path.isdir(base))
         self.assertTrue(os.path.isfile(os.path.join(base, 'format')))
-        with open(os.path.join(base, 'format'), 'rt') as stream:
+        with open(os.path.join(base, 'format')) as stream:
             contents = stream.read()
         self.assertEqual("1\n", contents)
-        with open(os.path.join(base, 'next-stream'), 'rt') as stream:
+        with open(os.path.join(base, 'next-stream')) as stream:
             contents = stream.read()
         self.assertEqual("0\n", contents)
 
@@ -81,10 +81,10 @@ class TestFileRepository(base.TestCase):
         self.repo = file.RepositoryFactory().initialise(self.tempdir)
         self.assertTrue(os.path.isdir(base))
         self.assertTrue(os.path.isfile(os.path.join(base, 'format')))
-        with open(os.path.join(base, 'format'), 'rt') as stream:
+        with open(os.path.join(base, 'format')) as stream:
             contents = stream.read()
         self.assertEqual("1\n", contents)
-        with open(os.path.join(base, 'next-stream'), 'rt') as stream:
+        with open(os.path.join(base, 'next-stream')) as stream:
             contents = stream.read()
         self.assertEqual("0\n", contents)
 

--- a/stestr/tests/repository/test_sql.py
+++ b/stestr/tests/repository/test_sql.py
@@ -27,18 +27,18 @@ from stestr.tests import base
 class SqlRepositoryFixture(fixtures.Fixture):
 
     def __init__(self, url=None):
-        super(SqlRepositoryFixture, self).__init__()
+        super().__init__()
         self.url = url
 
     def setUp(self):
-        super(SqlRepositoryFixture, self).setUp()
+        super().setUp()
         self.repo = sql.RepositoryFactory().initialise(self.url)
 
 
 class TestSqlRepository(base.TestCase):
 
     def setUp(self):
-        super(TestSqlRepository, self).setUp()
+        super().setUp()
         # NOTE(mtreinish): Windows likes to fail if the file is already open
         # when we access it later, so lets explicitly close it before we move
         # forward

--- a/stestr/tests/repository/test_util.py
+++ b/stestr/tests/repository/test_util.py
@@ -22,7 +22,7 @@ from stestr.tests import base
 class TestUtil(base.TestCase):
 
     def setUp(self):
-        super(TestUtil, self).setUp()
+        super().setUp()
         self.temp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.temp_dir)
         cwd = os.getcwd()

--- a/stestr/tests/test_bisect_return_codes.py
+++ b/stestr/tests/test_bisect_return_codes.py
@@ -20,7 +20,7 @@ from stestr.tests import base
 
 class TestBisectReturnCodes(base.TestCase):
     def setUp(self):
-        super(TestBisectReturnCodes, self).setUp()
+        super().setUp()
         # Setup test dirs
         self.directory = tempfile.mkdtemp(prefix='stestr-unit')
         self.addCleanup(shutil.rmtree, self.directory)

--- a/stestr/tests/test_bisect_tests.py
+++ b/stestr/tests/test_bisect_tests.py
@@ -132,7 +132,7 @@ class FakeFailedMultiWorkerTestRunWithTags(FakeTestRun):
 
 class TestBisectTests(base.TestCase):
     def setUp(self):
-        super(TestBisectTests, self).setUp()
+        super().setUp()
         self.repo_mock = mock.create_autospec(
             'stestr.repository.file.Repository')
         self.conf_mock = mock.create_autospec('stestr.config_file.TestrConf')

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -23,7 +23,7 @@ class TestTestrConf(base.TestCase):
 
     @mock.patch.object(config_file.configparser, 'ConfigParser')
     def setUp(self, mock_ConfigParser):
-        super(TestTestrConf, self).setUp()
+        super().setUp()
         self._testr_conf = config_file.TestrConf(mock.sentinel.config_file)
         self._testr_conf.parser = mock.Mock()
 

--- a/stestr/tests/test_output.py
+++ b/stestr/tests/test_output.py
@@ -33,7 +33,7 @@ class TestOutput(base.TestCase):
             self.assertEqual(expected, actual)
 
     def test_output_tests(self):
-        class Test(object):
+        class Test:
             def __init__(self, i):
                 self.i = i
 

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -31,7 +31,7 @@ from stestr.tests import base
 
 class TestReturnCodes(base.TestCase):
     def setUp(self):
-        super(TestReturnCodes, self).setUp()
+        super().setUp()
         # Setup test dirs
         self.directory = tempfile.mkdtemp(prefix='stestr-unit')
         self.addCleanup(shutil.rmtree, self.directory, ignore_errors=True)

--- a/stestr/tests/test_subunit_trace.py
+++ b/stestr/tests/test_subunit_trace.py
@@ -31,7 +31,7 @@ from stestr.tests import base
 class TestSubunitTrace(base.TestCase):
 
     def setUp(self):
-        super(TestSubunitTrace, self).setUp()
+        super().setUp()
         # NOTE(mtreinish): subunit-trace relies on a global to track results
         # with the expectation that it's run once per python interpreter
         # (like per stestr run or other command). Make sure to clear those on

--- a/stestr/tests/test_test_processor.py
+++ b/stestr/tests/test_test_processor.py
@@ -20,7 +20,7 @@ from stestr.tests import base
 class TestTestProcessorFixture(base.TestCase):
 
     def setUp(self):
-        super(TestTestProcessorFixture, self).setUp()
+        super().setUp()
         self._fixture = test_processor.TestProcessorFixture(
             mock.sentinel.test_ids, mock.sentinel.options,
             mock.sentinel.cmd_template, mock.sentinel.listopt,

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -57,7 +57,7 @@ run:
 class TestUserConfig(base.TestCase):
 
     def setUp(self):
-        super(TestUserConfig, self).setUp()
+        super().setUp()
         home_dir = os.path.expanduser("~")
         self.xdg_path = os.path.join(os.path.join(home_dir, '.config'),
                                      'stestr.yaml')

--- a/stestr/tests/test_user_config_return_codes.py
+++ b/stestr/tests/test_user_config_return_codes.py
@@ -26,7 +26,7 @@ from stestr.tests import base
 
 class TestReturnCodes(base.TestCase):
     def setUp(self):
-        super(TestReturnCodes, self).setUp()
+        super().setUp()
         # Setup test dirs
         self.directory = tempfile.mkdtemp(prefix='stestr-unit')
         self.addCleanup(shutil.rmtree, self.directory)

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -36,7 +36,7 @@ def get_user_config(path=None):
     return UserConfig(path)
 
 
-class UserConfig(object):
+class UserConfig:
 
     def __init__(self, path):
         self.schema = vp.Schema({
@@ -68,7 +68,7 @@ class UserConfig(object):
                 vp.Optional('all-attachments'): bool,
             }
         })
-        with open(path, 'r') as fd:
+        with open(path) as fd:
             self.config = yaml.safe_load(fd.read())
         if self.config is None:
             self.config = {}

--- a/stestr/utils.py
+++ b/stestr/utils.py
@@ -15,7 +15,7 @@ import io
 from stestr import output
 
 
-class CallWhenProcFinishes(object):
+class CallWhenProcFinishes:
     """Convert a process object to trigger a callback when returncode is set.
 
     This just wraps the entire object and when the returncode attribute access


### PR DESCRIPTION
Since stestr 3.0.0 stestr has only supported Python>=3.5 and we've
already removed a bunch of compatibility code for Python 2 support.
However, there were a lot of places in the stestr code where we were
using older connventions and syntax when there was newer conventions
available that typically are more consise. This commit updates the
syntax to use python3 conventions everywhere. This was done by using the
pyupgrade [1] tool and then fixing places where it didn't work as
expected.

[1] https://pypi.org/project/pyupgrade/