### PR TITLE
Add history commands to stestr

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -499,6 +499,13 @@ that changes the default on all available options in the config file is::
       abbreviate: True
       suppress-attachments: True
       all-attachments: True
+    history-list:
+      show-metadata: True
+    history-show:
+      no-subunit-trace: True
+      color: True
+      suppress-attachments: True
+      all-attachments: True
 
 If you choose to use a user config file you can specify any subset of the
 options and commands you choose.
@@ -559,6 +566,23 @@ using the failing set, or a user supplied load-list), and then spawns one test
 runner per test it runs. To avoid cross-test-runner interactions concurrency
 is disabled in this mode. ``--analyze-isolation`` supersedes ``--isolated`` if
 they are both supplied.
+
+History
+-------
+
+stestr keeps a history of all test runs in a local repository. the
+``stestr history`` command is used for interacting with those old runs. The
+history command has 3 sub-commands, ``list``, ``show``, and ``remove``. The
+``list`` sub-command will generate a list of the previous runs in the data
+repository and show some basic stats for each run. The ``show`` sub-command is
+used to retreive the record of a previous run, it behaves identically to
+``stestr last``, except that it takes an optional run id to show any run in the
+stestr history. If a run id is not specified it will use the most recent
+result. The ``remove`` sub-command will delete a specified run from the data
+repository. Additionally, the keyword ``all`` can be used to remove all runs
+from the repository. For example::
+
+  $ stestr history remove all
 
 Repositories
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 future
 pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
-PrettyTable>=0.7.2 # BSD
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.4.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 future
 pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
+PrettyTable>=0.7.2 # BSD
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.4.0 # Apache-2.0/BSD
 fixtures>=3.0.0 # Apache-2.0/BSD

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,9 @@ stestr.cm =
     list = stestr.commands.list:List
     load = stestr.commands.load:Load
     slowest = stestr.commands.slowest:Slowest
-    history = stestr.commands.history:History
+    history_list = stestr.commands.history:HistoryList
+    history_show = stestr.commands.history:HistoryShow
+    history_remove = stestr.commands.history:HistoryRemove
 
 [extras]
 sql =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ stestr.cm =
     list = stestr.commands.list:List
     load = stestr.commands.load:Load
     slowest = stestr.commands.slowest:Slowest
+    history = stestr.commands.history:History
 
 [extras]
 sql =

--- a/stestr/commands/__init__.py
+++ b/stestr/commands/__init__.py
@@ -11,6 +11,9 @@
 # under the License.
 
 from stestr.commands.failing import failing as failing_command
+from stestr.commands.history import history_list as history_list_command
+from stestr.commands.history import history_remove as history_remove_command
+from stestr.commands.history import history_show as history_show_command
 from stestr.commands.init import init as init_command
 from stestr.commands.last import last as last_command
 from stestr.commands.list import list_command
@@ -18,5 +21,8 @@ from stestr.commands.load import load as load_command
 from stestr.commands.run import run_command
 from stestr.commands.slowest import slowest as slowest_command
 
+
 __all__ = ['failing_command', 'init_command', 'last_command',
-           'list_command', 'load_command', 'run_command', 'slowest_command']
+           'list_command', 'load_command', 'run_command', 'slowest_command',
+           'history_show_command', 'history_list_command',
+           'history_remove_command']

--- a/stestr/commands/history.py
+++ b/stestr/commands/history.py
@@ -1,0 +1,383 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Interact with the run history in a repository."""
+
+import functools
+import sys
+
+from cliff import command
+import prettytable
+import subunit
+import testtools
+
+from stestr import output
+from stestr.repository import abstract
+from stestr.repository import util
+from stestr import results
+from stestr import subunit_trace
+from stestr import user_config
+
+
+class History(command.Command):
+    """Interact with the run history in a repository."""
+
+    def get_parser(self, prog_name):
+        parser = super().get_parser(prog_name)
+        cmd_parser = parser.add_subparsers()
+        list_parser = cmd_parser.add_parser('list',
+                                            help='list runs in repository')
+        list_parser.set_defaults(func='list')
+        list_parser.add_argument('--show-metadata', '-m', action='store_true',
+                                 help="Show metadata associated with runs in "
+                                      "output table")
+
+        # Configure show subcommand:
+        show_parser = cmd_parser.add_parser('show',
+                                            help='Show the contents of a '
+                                                 'single run in the history')
+        show_parser.add_argument(
+            "--subunit", action="store_true",
+            default=False, help="Show output as a subunit stream.")
+        show_parser.set_defaults(func='show')
+        show_parser.add_argument("--no-subunit-trace", action='store_true',
+                                 default=False,
+                                 help="Disable output with the subunit-trace "
+                                      "output filter")
+        show_parser.add_argument('--force-subunit-trace', action='store_true',
+                                 default=False,
+                                 help='Force subunit-trace output regardless '
+                                      'of any other options or config '
+                                      'settings')
+        show_parser.add_argument('--color', action='store_true', default=False,
+                                 help='Enable color output in the '
+                                      'subunit-trace output, if subunit-trace '
+                                      'output is enabled. (this is the '
+                                      'default). If subunit-trace is disabled '
+                                      'this does nothing.')
+        show_parser.add_argument('--suppress-attachments', action='store_true',
+                                 dest='suppress_attachments',
+                                 help='If set do not print stdout or stderr '
+                                      'attachment contents on a successful '
+                                      'test execution')
+        show_parser.add_argument('--all-attachments', action='store_true',
+                                 dest='all_attachments',
+                                 help='If set print all text attachment '
+                                      'contents on a successful test '
+                                      'execution')
+        show_parser.add_argument('--show-binary-attachments',
+                                 action='store_true',
+                                 dest='show_binary_attachments',
+                                 help='If set, show non-text attachments. '
+                                      'This is generally only useful for '
+                                      'debug purposes.')
+        show_parser.add_argument('run_id', nargs='?', default=None,
+                                 help='The run id to show the results from '
+                                      'if not specified the last run will be '
+                                      'shown (which is equivalent to '
+                                      "'stestr last')")
+        remove_parser = cmd_parser.add_parser('remove',
+                                              help='Remove runs from a '
+                                                   'repository')
+        remove_parser.set_defaults(func='remove')
+        remove_parser.add_argument('run_id',
+                                   help='The run id to remove from the '
+                                        'repository. Also the string "all" '
+                                        'can be used to remove all runs in '
+                                        'the history')
+        return parser
+
+    def take_action(self, parsed_args):
+        args = parsed_args
+        user_conf = user_config.get_user_config(self.app_args.user_config)
+        if args.func == 'list':
+            show_metadata = args.show_metadata
+            if getattr(user_conf, 'history_list', False):
+                if user_conf.history_show.get('show-metadata',
+                                              None) is not None:
+                    show_metadata = args.show_metadata
+            return history_list(repo_type=self.app_args.repo_type,
+                                repo_url=self.app_args.repo_url,
+                                show_metadata=show_metadata)
+        elif args.func == 'show':
+            if args.suppress_attachments and args.all_attachments:
+                msg = ("The --suppress-attachments and --all-attachments "
+                       "options are mutually exclusive, you can not use both "
+                       "at the same time")
+                print(msg)
+                sys.exit(1)
+            if getattr(user_conf, 'history_show', False):
+                if not user_conf.history_show.get('no-subunit-trace'):
+                    if not args.no_subunit_trace:
+                        pretty_out = True
+                    else:
+                        pretty_out = False
+                else:
+                    pretty_out = False
+                pretty_out = args.force_subunit_trace or pretty_out
+                color = args.color or user_conf.history_show.get('color',
+                                                                 False)
+                suppress_attachments_conf = user_conf.history_show.get(
+                    'suppress-attachments', False)
+                all_attachments_conf = user_conf.history_show.get(
+                    'all-attachments', False)
+                if not args.suppress_attachments and not args.all_attachments:
+                    suppress_attachments = suppress_attachments_conf
+                    all_attachments = all_attachments_conf
+                elif args.suppress_attachments:
+                    all_attachments = False
+                    suppress_attachments = args.suppress_attachments
+                elif args.all_attachments:
+                    suppress_attachments = False
+                    all_attachments = args.all_attachments
+            else:
+                pretty_out = args.force_subunit_trace or not \
+                    args.no_subunit_trace
+                color = args.color
+                suppress_attachments = args.suppress_attachments
+                all_attachments = args.all_attachments
+            return history_show(
+                args.run_id,
+                repo_type=self.app_args.repo_type,
+                repo_url=self.app_args.repo_url,
+                subunit_out=args.subunit,
+                pretty_out=pretty_out, color=color,
+                suppress_attachments=suppress_attachments,
+                all_attachments=all_attachments,
+                show_binary_attachments=args.show_binary_attachments)
+        elif args.func == 'remove':
+            history_remove(args.run_id, repo_type=self.app_args.repo_type,
+                           repo_url=self.app_args.repo_url)
+
+
+start_times = None
+stop_times = None
+
+
+def _get_run_details(stream_file, stdout):
+    stream = subunit.ByteStreamToStreamResult(stream_file,
+                                              non_subunit_name='stdout')
+    global start_times
+    global stop_times
+    start_times = []
+    stop_times = []
+
+    def collect_data(stream, test):
+        global start_times
+        global stop_times
+        start_times.append(test['timestamps'][0])
+        stop_times.append(test['timestamps'][1])
+
+    outcomes = testtools.StreamToDict(functools.partial(collect_data, stdout))
+    summary = testtools.StreamSummary()
+    result = testtools.CopyStreamResult([outcomes, summary])
+    result = testtools.StreamResultRouter(result)
+    cat = subunit.test_results.CatFiles(stdout)
+    result.add_rule(cat, 'test_id', test_id=None)
+    result.startTestRun()
+    try:
+        stream.run(result)
+    finally:
+        result.stopTestRun()
+    successful = results.wasSuccessful(summary)
+    if start_times and stop_times:
+        start_time = min(start_times)
+        stop_time = max(stop_times)
+        run_time = subunit_trace.get_duration([start_time, stop_time])
+    else:
+        run_time = '---'
+        successful = '---'
+        start_time = '---'
+    return {'passed': successful, 'runtime': run_time, 'start': start_time}
+
+
+def history_list(repo_type='file', repo_url=None, show_metadata=False,
+                 stdout=sys.stdout):
+    """Show a list of runs in a repository
+
+    Note this function depends on the cwd for the repository if `repo_type` is
+    set to file and `repo_url` is not specified it will use the repository
+    located at CWD/.stestr
+
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param bool show_metadata: If set to ``True`` a column with any metadata
+        for a run will be included in the output.
+    :param file stdout: The output file to write all output to. By default
+         this is sys.stdout
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
+    """
+
+    table = prettytable.PrettyTable()
+    if show_metadata:
+        table.field_names = ['Run ID', 'Passed', 'Runtime', 'Date', 'Metadata']
+    else:
+        table.field_names = ['Run ID', 'Passed', 'Runtime', 'Date']
+    try:
+        repo = util.get_repo_open(repo_type, repo_url)
+    except abstract.RepositoryNotFound as e:
+        stdout.write(str(e) + '\n')
+        return 1
+    try:
+        run_ids = repo.get_run_ids()
+    except KeyError as e:
+        stdout.write(str(e) + '\n')
+        return 1
+
+    for run_id in run_ids:
+        run = repo.get_test_run(run_id)
+        stream = run.get_subunit_stream()
+        data = _get_run_details(stream, stdout)
+        if show_metadata:
+            table.add_row([run_id, data['passed'], data['runtime'],
+                           data['start'], run.get_metadata()])
+        else:
+            table.add_row([run_id, data['passed'], data['runtime'],
+                           data['start']])
+    stdout.write(table.get_string() + '\n')
+    return 0
+
+
+def history_show(run_id, repo_type='file', repo_url=None, subunit_out=False,
+                 pretty_out=True, color=False, stdout=sys.stdout,
+                 suppress_attachments=False, all_attachments=False,
+                 show_binary_attachments=False):
+    """Show a run loaded into a repository
+
+    This function will print the results from the last run in the repository
+    to STDOUT. It can optionally print the subunit stream for the last run
+    to STDOUT if the ``subunit`` option is set to true.
+
+    Note this function depends on the cwd for the repository if `repo_type` is
+    set to file and `repo_url` is not specified it will use the repository
+    located at CWD/.stestr
+
+    :param str run_id: The run id to show
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param bool subunit_out: Show output as a subunit stream.
+    :param pretty_out: Use the subunit-trace output filter.
+    :param color: Enable colorized output with the subunit-trace output filter.
+    :param bool subunit: Show output as a subunit stream.
+    :param file stdout: The output file to write all output to. By default
+         this is sys.stdout
+    :param bool suppress_attachments: When set true attachments subunit_trace
+        will not print attachments on successful test execution.
+    :param bool all_attachments: When set true subunit_trace will print all
+        text attachments on successful test execution.
+    :param bool show_binary_attachments: When set to true, subunit_trace will
+        print binary attachments in addition to text attachments.
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
+    """
+    try:
+        repo = util.get_repo_open(repo_type, repo_url)
+    except abstract.RepositoryNotFound as e:
+        stdout.write(str(e) + '\n')
+        return 1
+    try:
+        if run_id:
+            run = repo.get_test_run(run_id)
+        else:
+            run = repo.get_latest_run()
+    except KeyError as e:
+        stdout.write(str(e) + '\n')
+        return 1
+
+    if subunit_out:
+        stream = run.get_subunit_stream()
+        output.output_stream(stream, output=stdout)
+        # Exits 0 if we successfully wrote the stream.
+        return 0
+    case = run.get_test()
+    try:
+        if repo_type == 'file':
+            if run_id:
+                previous_run = int(run_id) - 1
+            else:
+                previous_run = repo.get_test_run(repo.latest_id() - 1)
+        # TODO(mtreinish): add a repository api to get the previous_run to
+        # unify this logic
+        else:
+            previous_run = None
+    except KeyError:
+        previous_run = None
+    failed = False
+    if not pretty_out:
+        output_result = results.CLITestResult(run.get_id, stdout,
+                                              previous_run)
+        summary = output_result.get_summary()
+        output_result.startTestRun()
+        try:
+            case.run(output_result)
+        finally:
+            output_result.stopTestRun()
+        failed = not results.wasSuccessful(summary)
+    else:
+        stream = run.get_subunit_stream()
+        failed = subunit_trace.trace(
+            stream, stdout, post_fails=True, color=color,
+            suppress_attachments=suppress_attachments,
+            all_attachments=all_attachments,
+            show_binary_attachments=show_binary_attachments)
+    if failed:
+        return 1
+    else:
+        return 0
+
+
+def history_remove(run_id, repo_type='file', repo_url=None, stdout=sys.stdout):
+    """Remove a run from a repository
+
+    Note this function depends on the cwd for the repository if `repo_type` is
+    set to file and `repo_url` is not specified it will use the repository
+    located at CWD/.stestr
+
+    :param str run_id: The run id to remove from the repository. Also, can be
+        set to ``all`` which will remove all runs from the repository.
+    :param str repo_type: This is the type of repository to use. Valid choices
+        are 'file' and 'sql'.
+    :param str repo_url: The url of the repository to use.
+    :param file stdout: The output file to write all output to. By default
+         this is sys.stdout
+
+    :return return_code: The exit code for the command. 0 for success and > 0
+        for failures.
+    :rtype: int
+    """
+    try:
+        repo = util.get_repo_open(repo_type, repo_url)
+    except abstract.RepositoryNotFound as e:
+        stdout.write(str(e) + '\n')
+        return 1
+    if run_id == 'all':
+        try:
+            run_ids = repo.get_run_ids()
+        except KeyError as e:
+            stdout.write(str(e) + '\n')
+            return 1
+        for run_id in run_ids:
+            repo.remove_run_id(run_id)
+    else:
+        try:
+            repo.remove_run_id(run_id)
+        except KeyError as e:
+            stdout.write(str(e) + '\n')
+            return 1
+    return 0

--- a/stestr/repository/abstract.py
+++ b/stestr/repository/abstract.py
@@ -67,6 +67,17 @@ class AbstractRepository:
         """
         raise NotImplementedError(self.get_failing)
 
+    def get_run_ids(self):
+        """Get a list of test ids in the repository
+
+        :return: a list of test ids
+        """
+        raise NotImplementedError(self.get_run_ids)
+
+    def remove_run_id(self, run_id):
+        """Remove a run from the repository"""
+        raise NotImplementedError(self.remove_run_id)
+
     def get_inserter(self, partial=False, run_id=None, metadata=None):
         """Get an inserter that will insert a test run into the repository.
 

--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -110,6 +110,22 @@ class Repository(repository.AbstractRepository):
             raise KeyError("No tests in repository")
         return result
 
+    def get_run_ids(self):
+        result = []
+        max_id = self._next_stream()
+        if max_id < 0:
+            raise KeyError("No tests in repository")
+        for i in range(max_id):
+            if os.path.isfile(os.path.join(self.base, str(i))):
+                result.append(str(i))
+        return result
+
+    def remove_run_id(self, run_id):
+        run_path = os.path.join(self.base, run_id)
+        if not os.path.isfile(run_path):
+            raise KeyError("No run %s in repository" % run_id)
+        os.remove(run_path)
+
     def get_failing(self):
         try:
             with open(os.path.join(self.base, "failing"), 'rb') as fp:

--- a/stestr/repository/memory.py
+++ b/stestr/repository/memory.py
@@ -66,6 +66,14 @@ class Repository(repository.AbstractRepository):
             raise KeyError("No such run.")
         return self._runs[run_id]
 
+    def get_run_ids(self):
+        return list(self._runs.keys())
+
+    def remove_run_id(self, run_id):
+        if run_id not in self._runs:
+            raise KeyError("No run %s in repository" % run_id)
+        del self._run[run_id]
+
     def latest_id(self):
         result = self.count() - 1
         if result < 0:

--- a/stestr/repository/sql.py
+++ b/stestr/repository/sql.py
@@ -111,6 +111,22 @@ class Repository(repository.AbstractRepository):
         session.close()
         return _Subunit2SqlRun(self.base, None, test_runs=failed_test_runs)
 
+    def get_run_ids(self):
+        session = self.session_factory()
+        res = [run.uuid for run in db_api.get_all_runs(
+            session=self.session_factory())]
+        session.close()
+        return res
+
+    def remove_run_id(self, run_id):
+        session = self.session_factory()
+        try:
+            db_api.delete_run_by_uuid(run_id, session=session)
+        except TypeError:
+            raise KeyError("run_id %s not in repository")
+        session.commit()
+        session.close()
+
     def get_test_run(self, run_id):
         return _Subunit2SqlRun(self.base, run_id)
 

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -405,6 +405,9 @@ def trace(stdin, stdout, print_failures=False, failonly=False,
         stop_times += [
             x['timestamps'][1] for x in RESULTS[worker] if
             x['timestamps'][1] is not None]
+    if not start_times:
+        print("The test run didn't actually run any tests", file=sys.stderr)
+        return 1
     start_time = min(start_times)
     stop_time = max(stop_times)
     elapsed_time = stop_time - start_time

--- a/stestr/tests/repository/test_file.py
+++ b/stestr/tests/repository/test_file.py
@@ -166,3 +166,48 @@ class TestFileRepository(base.TestCase):
         run_ids_int = [int(x) for x in run_ids]
         self.assertIn(result.get_id(), run_ids_int)
         self.assertNotIn(result_bad.get_id(), run_ids_int)
+
+    def test_get_run_ids(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter(metadata='fun')
+        result.startTestRun()
+        result.stopTestRun()
+        result_bad = repo.get_inserter(metadata='not_fun')
+        result_bad.startTestRun()
+        result_bad.stopTestRun()
+        run_ids = repo.get_run_ids()
+        self.assertEqual(['0', '1'], run_ids)
+
+    def test_get_run_ids_empty(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        run_ids = repo.get_run_ids()
+        self.assertEqual([], run_ids)
+
+    def test_get_run_ids_with_hole(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter()
+        result.startTestRun()
+        result.stopTestRun()
+        result = repo.get_inserter()
+        result.startTestRun()
+        result.stopTestRun()
+        result = repo.get_inserter()
+        result.startTestRun()
+        result.stopTestRun()
+        repo.remove_run_id('1')
+        self.assertEqual(['0', '2'], repo.get_run_ids())
+
+    def test_remove_ids(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter()
+        result.startTestRun()
+        result.stopTestRun()
+        repo.remove_run_id('0')
+        self.assertEqual([], repo.get_run_ids())
+
+    def test_remove_ids_id_not_in_repo(self):
+        repo = self.useFixture(FileRepositoryFixture()).repo
+        result = repo.get_inserter()
+        result.startTestRun()
+        result.stopTestRun()
+        self.assertRaises(KeyError, repo.remove_run_id, '3')

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -337,12 +337,12 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr run passing', 0)
         table = self.assertRunExit(
             'stestr history list', 0)[0].decode('utf8')
-        self.assertIn("|   0    |  True  |", table.split('\n')[3].rstrip())
-        self.assertIn("|   1    | False  |", table.split('\n')[4].rstrip())
-        self.assertIn("|   2    |  True  |", table.split('\n')[5].rstrip())
+        self.assertIn("| 0      | True   |", table.split('\n')[3].rstrip())
+        self.assertIn("| 1      | False  |", table.split('\n')[4].rstrip())
+        self.assertIn("| 2      | True   |", table.split('\n')[5].rstrip())
         expected = """
 +--------+--------+-----------+----------------------------------+
-| Run ID | Passed |  Runtime  |               Date               |
+| Run ID | Passed | Runtime   | Date                             |
 +--------+--------+-----------+----------------------------------+
 """.rstrip()
         self.assertEqual(expected.strip(), '\n'.join(
@@ -351,13 +351,7 @@ class TestReturnCodes(base.TestCase):
     def test_history_empty(self):
         table = self.assertRunExit(
             'stestr history list', 0)[0].decode('utf8')
-        expected = """
-+--------+--------+---------+------+
-| Run ID | Passed | Runtime | Date |
-+--------+--------+---------+------+
-+--------+--------+---------+------+
-"""
-        self.assertEqual(expected.strip(),
+        self.assertEqual("",
                          '\n'.join(
                              [x.rstrip() for x in table.split('\n')]).strip())
 
@@ -396,12 +390,12 @@ class TestReturnCodes(base.TestCase):
         self.assertRunExit('stestr history remove 1', 0)
         table = self.assertRunExit(
             'stestr history list', 0)[0].decode('utf8')
-        self.assertIn("|   0    |  True  |", table.split('\n')[3].rstrip())
-        self.assertNotIn("|   1    | False  |", table.split('\n')[4].strip())
-        self.assertIn("|   2    |  True  |", table.split('\n')[4].rstrip())
+        self.assertIn("| 0      | True   |", table.split('\n')[3].rstrip())
+        self.assertNotIn("| 1      | False  |", table.split('\n')[4].strip())
+        self.assertIn("| 2      | True   |", table.split('\n')[4].rstrip())
         expected = """
 +--------+--------+-----------+----------------------------------+
-| Run ID | Passed |  Runtime  |               Date               |
+| Run ID | Passed | Runtime   | Date                             |
 +--------+--------+-----------+----------------------------------+
 """.strip()
         self.assertEqual(expected, '\n'.join(

--- a/stestr/tests/test_user_config.py
+++ b/stestr/tests/test_user_config.py
@@ -41,6 +41,13 @@ load:
   abbreviate: True
   suppress-attachments: True
   all-attachments: True
+history-list:
+  show-metadata: True
+history-show:
+  no-subunit-trace: True
+  color: True
+  suppress-attachments: True
+  all-attachments: True
 """
 
 INVALID_YAML_FIELD = """
@@ -152,7 +159,14 @@ class TestUserConfig(base.TestCase):
                 'color': True,
                 'abbreviate': True,
                 'suppress-attachments': True,
-                'all-attachments': True}
+                'all-attachments': True},
+            'history-list': {
+                'show-metadata': True},
+            'history-show': {
+                'no-subunit-trace': True,
+                'color': True,
+                'suppress-attachments': True,
+                'all-attachments': True},
         }
         self.assertEqual(full_dict, user_conf.config)
 

--- a/stestr/user_config.py
+++ b/stestr/user_config.py
@@ -66,6 +66,15 @@ class UserConfig:
                 vp.Optional('abbreviate'): bool,
                 vp.Optional('suppress-attachments'): bool,
                 vp.Optional('all-attachments'): bool,
+            },
+            vp.Optional('history-list'): {
+                vp.Optional('show-metadata'): bool,
+            },
+            vp.Optional('history-show'): {
+                vp.Optional('no-subunit-trace'): bool,
+                vp.Optional('color'): bool,
+                vp.Optional('suppress-attachments'): bool,
+                vp.Optional('all-attachments'): bool,
             }
         })
         with open(path) as fd:
@@ -94,3 +103,11 @@ class UserConfig:
     @property
     def load(self):
         return self.config.get('load')
+
+    @property
+    def history_list(self):
+        return self.config.get('history-list')
+
+    @property
+    def history_show(self):
+        return self.config.get('history-show')


### PR DESCRIPTION
This commit adds a new command to stestr, history. The history command
is used for interacting with the history of results in the repository.
Prior to this commit you could only interact with the most recent run in
the repository via the last command, but anything older was just taking
up disk space and never used. The history command to start has 3
subcommands, 'list', 'show', and 'remove'. List will generate a table of
all the contents of the repository that will show the run id, the result
of the run, when it started, how long it took, and optionally show any
metadata for the run. Show will show a run in the repository, this is
equivalent to 'stestr last', but takes an optional run id instead of just
unconditionally showing the last run. Remove is used to remove runs from
the repository, this is useful if you don't need the history anymore and
want to clean up some disk space.

Fixes #303
Starts #224

TODO:

- [x] Add tests
- [x] Add user config support for default outputs
- [x] Add support for subunit2sql repositories
- [x] Fix docs builds (looks like it's caused by subcommands on a cliff `Command` breaking the sphinx extension)