### PR TITLE
Deprecate the sql repository type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install and run tests macOS
         run: |
           tox -epy --notest
-          .tox/py/bin/pip install gnureadline
+          .tox/py/bin/pip install gnureadline subunit2sql
           tox -epy
         if: runner.os == 'macOS'
   lint:

--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -621,12 +621,13 @@ contains the following files:
 SQL
 '''
 This is an experimental repository backend, that is based on the `subunit2sql`_
-library. It's currently still under development and should be considered
-experimental for the time being. Eventually it'll replace the File repository
-type
+library.
 
 .. note:: The sql repository type requirements are not installed by default.
     They are listed under the 'sql' setuptools extras. You can install them
     with pip by running: ``pip install 'stestr[sql]'``
+
+.. warning:: The sql repository type is deprecated and will be removed in the
+   4.0.0 release.
 
 .. _subunit2sql:

--- a/stestr/cli.py
+++ b/stestr/cli.py
@@ -70,7 +70,7 @@ class StestrCLI(app.App):
                                  " is running from is used")
         parser.add_argument('--repo-type', '-r', dest='repo_type',
                             choices=['file', 'sql'], default='file',
-                            help="Select the repo backend to use")
+                            help="DEPRECATED: Select the repo backend to use")
         parser.add_argument('--repo-url', '-u', dest='repo_url',
                             default=None,
                             help="Set the repo url to use. An acceptable value"

--- a/stestr/commands/init.py
+++ b/stestr/commands/init.py
@@ -14,6 +14,7 @@
 
 import errno
 import sys
+import warnings
 
 from cliff import command
 
@@ -45,6 +46,12 @@ def init(repo_type='file', repo_url=None, stdout=sys.stdout):
         for failures.
     :rtype: int
     """
+    if repo_type == 'sql':
+        msg = ("WARNING: The sql repository type is deprecated and will be "
+               "removed in the 4.0.0 release. Instead use the file "
+               "repository type\n")
+        sys.stderr.write(msg)
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     try:
         util.get_repo_initialise(repo_type, repo_url)
     except OSError as e:

--- a/stestr/repository/sql.py
+++ b/stestr/repository/sql.py
@@ -73,7 +73,7 @@ class RepositoryFactory(repository.AbstractRepositoryFactory):
 
 
 class Repository(repository.AbstractRepository):
-    """subunit2sql based storage of test results.
+    """DEPRECATED: subunit2sql based storage of test results.
 
     This repository stores each stream in a subunit2sql DB. Refer to the
     subunit2sql documentation for

--- a/stestr/repository/util.py
+++ b/stestr/repository/util.py
@@ -13,6 +13,7 @@
 import importlib
 import os
 import sys
+import warnings
 
 
 def _get_default_repo_url(repo_type):
@@ -33,6 +34,12 @@ def get_repo_open(repo_type, repo_url=None):
     :param str repo_url: An optional repo url, if one is not specified the
         default $CWD/.stestr will be used.
     """
+    if repo_type == 'sql':
+        msg = ("WARNING: The sql repository type is deprecated and will be "
+               "removed in the 4.0.0 release. Instead use the file "
+               "repository type\n")
+        sys.stderr.write(msg)
+        warnings.warn(msg, DeprecationWarning, stacklevel=3)
     try:
         repo_module = importlib.import_module('stestr.repository.' + repo_type)
     except ImportError:

--- a/stestr/tests/repository/test_sql.py
+++ b/stestr/tests/repository/test_sql.py
@@ -20,8 +20,13 @@ import uuid
 import fixtures
 import testtools
 
-from stestr.repository import sql
 from stestr.tests import base
+
+try:
+    from stestr.repository import sql
+    HAS_SQL = True
+except ImportError:
+    HAS_SQL = False
 
 
 class SqlRepositoryFixture(fixtures.Fixture):
@@ -36,7 +41,7 @@ class SqlRepositoryFixture(fixtures.Fixture):
 
 
 class TestSqlRepository(base.TestCase):
-
+    @testtools.skipUnless(HAS_SQL, 'subunit2sql is required for tests')
     def setUp(self):
         super().setUp()
         # NOTE(mtreinish): Windows likes to fail if the file is already open

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,6 @@
 
 hacking<3.2.0,>=3.1.0
 sphinx>2.1.0 # BSD
-subunit2sql>=1.8.0
 coverage>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT
 doc8>=0.8.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ commands =
     coverage html -d cover
 
 [testenv:docs]
+extras =
+  sql
 commands =
   doc8 -e .rst doc/source CONTRIBUTING.rst README.rst
   python setup.py build_sphinx


### PR DESCRIPTION
This commit deprecates the sql repository type for future removal in the
next major version release (4.0.0). Included in this deprecation is the
`--repo-type`argument which only makes sense with >1 repository type. The
sql repository type depends on the subunit2sql project which is not
really active anymore. It never managed to reach feature parity with the
default file repository type and has been listed as experimental it's
whole existence. At this point it's realistically never going to replace
the file repository which was the original long term plan. One note is
that we both emit a `DeprecationWarning` and print a warning to stderr
when the sql repository type is set. This is because in my local testing
the `DeprecationWarning` was not actually show to the user, but I left it
in place because it is the standard python mechanism for these things.

Additionally, since we're deprecating the repository type to save some
CI time and complexity I removed the sql repository tests from the
default test run. We still run it in the macOS CI jobs to ensure we
don't regress during the deprecation but we don't need to spend time
running it in every run.

Fixes #307