### PR TITLE
Update package metadata field names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = stestr
 summary =  A parallel Python test runner built around subunit
-description-file =
+description_file =
     README.rst
 author = Matthew Treinish
-author-email = mtreinish@kortar.org
-home-page = http://stestr.readthedocs.io/en/latest/
+author_email = mtreinish@kortar.org
+home_page = http://stestr.readthedocs.io/en/latest/
 license = Apache-2.0
 classifier =
     Intended Audience :: Information Technology
@@ -26,7 +26,7 @@ project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-python-requires = >=3.5
+python_requires = >=3.5
 
 [files]
 packages =


### PR DESCRIPTION
In recent version of setuptools installing stestr has started raising
deprecation warnings about some of the metadata fields we were setting.
This commit updates the setup.cfg to use the names that are not
deprecated to fix the warnings and avoid having issues with a future
release of setuptools when the fields are removed.