### PR TITLE
Fix inprogress test detection

### DIFF
--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -426,8 +426,8 @@ def trace(stdin, stdout, print_failures=False, failonly=False,
         print("\nNo tests were successful during the run", file=sys.stderr)
         return 1
     in_progress = get_stuck_in_progress()
-    if count_tests('status', '^inprogress$') > 0:
-        print("\nThe following tests exited without returning a status \n"
+    if in_progress:
+        print("\nThe following tests exited without returning a status\n"
               "and likely segfaulted or crashed Python:", file=sys.stderr)
         for test in in_progress:
             print("\n\t* %s" % test, file=sys.stderr)


### PR DESCRIPTION
In #304 we attempted to add an error message when a test fails prior to
reporting its final status (like in case of a segfault). However, that
PR didn't work as intended because the condition to check if there were
any tests inprogress was incorrect. It relied on the count_tests()
function in subunit_trace which was returning zero as it was called
there even when tests were left in the inprogress state. However, this
call wasn't actually needed because we call get_stuck_in_progress()
right before the condition which collects any test ids from the subunit
stream that are left inprogress. This commit fixes the issue by just
checking that the output list from get_stuck_in_progress() has entries.
Then to ensure this doesn't regress in the future the unittest added in
PR #304 is updated to actually assert we write out the error message as
expected. Previously it only checked the return code was a failure
(which it was even before #304) which is what let this issue slip in.