### PR TITLE
Remove deprecated command line flags

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -190,12 +190,6 @@ list file is used in conjunction with the normal filters then the regex filters
 passed in as an argument regex will be used for the initial test selection, and
 the exclusion regexes from the exclusion list file on top of that.
 
-.. note::
-    DEPRECATION WARNING:
-    Previously the option ``--blacklist-file``/``-b`` was available for this
-    functionality. While it is still available at this time, it is soon to be
-    replaced by the new (equivalent) option ``--exclude-list``/``-e``.
-
 The dual of the exclusion list file is the inclusion list file which will
 include any tests matching the regexes in the file. You can specify the path to
 the file with ``--include-list``/``-i``, for example::
@@ -209,12 +203,6 @@ The format for the file is more or less identical to the exclusion list file::
   .*regex2 # include those tests
 
 However, instead of excluding the matches it will include them.
-
-.. note::
-    DEPRECATION WARNING:
-    Previously the option ``--whitelist-file``/``-w`` was available for this
-    functionality. While it is still available at this time, it is soon to be
-    replaced by the new (equivalent) option ``--include-list``/``-i``.
 
 It's also worth noting that you can use the test list option to dry run any
 selection arguments you are using. You just need to use ``stestr list``

--- a/stestr/commands/list.py
+++ b/stestr/commands/list.py
@@ -15,7 +15,6 @@
 from io import BytesIO
 import os
 import sys
-import warnings
 
 from cliff import command
 
@@ -37,38 +36,15 @@ class List(command.Command):
                             "apply on the test list. Tests that match any of "
                             "the regexes will be used. (assuming any other "
                             "filtering specified also uses it)")
-        parser.add_argument('--blacklist-file', '-b',
-                            default=None, dest='blacklist_file',
-                            help='DEPRECATED: This option will soon be  '
-                                 'replaced by --exclude-list which is '
-                                 'functionally equivalent. If this is '
-                                 'specified at the same time as '
-                                 '--exclude-list, this flag will be ignored '
-                                 'and --exclude-list will be used')
         parser.add_argument('--exclude-list', '-e',
                             default=None, dest='exclude_list',
                             help='Path to an exclusion list file, this file '
                                  'contains a separate regex exclude on each '
                                  'newline')
-        parser.add_argument('--whitelist-file', '-w',
-                            default=None, dest='whitelist_file',
-                            help='DEPRECATED: This option will soon be  '
-                                 'replaced by --include-list which is '
-                                 'functionally equivalent. If this is '
-                                 'specified at the same time as '
-                                 '--include-list, this flag will be ignored '
-                                 'and --include-list will be used')
         parser.add_argument('--include-list', '-i',
                             default=None, dest='include_list',
                             help='Path to an inclusion list file, this file '
                                  'contains a separate regex on each newline.')
-        parser.add_argument('--black-regex', '-B',
-                            default=None, dest='black_regex',
-                            help='DEPRECATED: This option will soon be  '
-                            'replaced by --exclude-regex which is '
-                            'functionally equivalent. If this is specified at '
-                            'the same time as --exclude-regex, this flag will '
-                            'be ignored and --exclude-regex will be used')
         parser.add_argument('--exclude-regex', '-E',
                             default=None, dest='exclude_regex',
                             help='Test rejection regex. If a test cases name '
@@ -90,20 +66,17 @@ class List(command.Command):
                             group_regex=self.app_args.group_regex,
                             test_path=self.app_args.test_path,
                             top_dir=self.app_args.top_dir,
-                            blacklist_file=args.blacklist_file,
                             exclude_list=args.exclude_list,
-                            whitelist_file=args.whitelist_file,
                             include_list=args.include_list,
-                            black_regex=args.black_regex,
                             exclude_regex=args.exclude_regex,
                             filters=filters)
 
 
 def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
                  test_path=None, top_dir=None, group_regex=None,
-                 blacklist_file=None, exclude_list=None,
-                 whitelist_file=None, include_list=None,
-                 black_regex=None, exclude_regex=None, filters=None,
+                 exclude_list=None,
+                 include_list=None,
+                 exclude_regex=None, filters=None,
                  stdout=sys.stdout):
     """Print a list of test_ids for a project
 
@@ -124,19 +97,10 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
     :param str group_regex: Set a group regex to use for grouping tests
         together in the stestr scheduler. If both this and the corresponding
         config file option are set this value will be used.
-    :param str blacklist_file: DEPRECATED: soon to be replaced by the new
-        option exclude_list below. If this is specified at the same time as
-        exclude_list , this flag will be ignored and exclude_list will be used
     :param str exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
-    :param str whitelist_file: DEPRECATED: soon to be replaced by the new
-        option include_list below. If this is specified at the same time as
-        include_list , this flag will be ignored and include_list will be used
     :param str include_list: Path to an inclusion list file, this file
         contains a separate regex on each newline.
-    :param str black_regex: DEPRECATED: soon to be replaced by the new
-        option exclude_regex below. If this is specified at the same time as
-        exclude_regex, this flag will be ignored and exclude_regex will be used
     :param str exclude_regex: Test rejection regex. If a test cases name
         matches on re.search() operation, it will be removed from the final
         test list.
@@ -147,21 +111,6 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
         this is sys.stdout
 
     """
-    if blacklist_file is not None:
-        warnings.warn("The blacklist-file argument is deprecated and will be "
-                      "removed in a future release. Instead you should use "
-                      "exclude-list which is functionally equivalent",
-                      DeprecationWarning)
-    if whitelist_file is not None:
-        warnings.warn("The whitelist-file argument is deprecated and will be "
-                      "removed in a future release. Instead you should use "
-                      "include-list which is functionally equivalent",
-                      DeprecationWarning)
-    if black_regex is not None:
-        warnings.warn("The black-regex argument is deprecated and will be "
-                      "removed in a future release. Instead you should use "
-                      "exclude-regex which is functionally equivalent",
-                      DeprecationWarning)
     ids = None
     if config and os.path.isfile(config):
         conf = config_file.TestrConf(config)
@@ -172,12 +121,11 @@ def list_command(config='.stestr.conf', repo_type='file', repo_url=None,
     cmd = conf.get_run_command(
         regexes=filters, repo_type=repo_type,
         repo_url=repo_url, group_regex=group_regex,
-        blacklist_file=blacklist_file, exclude_list=exclude_list,
-        whitelist_file=whitelist_file, include_list=include_list,
-        black_regex=black_regex, exclude_regex=exclude_regex,
+        exclude_list=exclude_list,
+        include_list=include_list,
+        exclude_regex=exclude_regex,
         test_path=test_path, top_dir=top_dir)
-    not_filtered = filters is None and blacklist_file is None\
-        and whitelist_file is None and black_regex is None\
+    not_filtered = filters is None\
         and include_list is None and exclude_list is None\
         and exclude_regex is None
     try:

--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -17,7 +17,6 @@ import errno
 import functools
 import os
 import sys
-import warnings
 
 from cliff import command
 import subunit
@@ -51,11 +50,6 @@ class Load(command.Command):
         parser.add_argument("files", nargs="*", default=False,
                             help="The subunit v2 stream files to load into the"
                             " repository")
-        parser.add_argument("--partial", action="store_true",
-                            default=False,
-                            help="DEPRECATED: The stream being loaded was a "
-                            "partial run. This option is deprecated and no "
-                            "does anything. It will be removed in the future")
         parser.add_argument("--force-init", action="store_true",
                             default=False,
                             help="Initialise the repository if it does not "
@@ -133,7 +127,7 @@ class Load(command.Command):
         stdout = open(os.devnull, 'w') if verbose_level == 0 else sys.stdout
         load(repo_type=self.app_args.repo_type,
              repo_url=self.app_args.repo_url,
-             partial=args.partial, subunit_out=args.subunit,
+             subunit_out=args.subunit,
              force_init=force_init, streams=args.files,
              pretty_out=pretty_out, color=color,
              stdout=stdout, abbreviate=abbreviate,
@@ -143,7 +137,7 @@ class Load(command.Command):
 
 
 def load(force_init=False, in_streams=None,
-         partial=False, subunit_out=False, repo_type='file', repo_url=None,
+         subunit_out=False, repo_type='file', repo_url=None,
          run_id=None, streams=None, pretty_out=False, color=False,
          stdout=sys.stdout, abbreviate=False, suppress_attachments=False,
          serial=False, all_attachments=False, show_binary_attachments=False):
@@ -158,9 +152,6 @@ def load(force_init=False, in_streams=None,
         been created.
     :param list in_streams: A list of file objects that will be saved into the
         repository
-    :param bool partial: DEPRECATED: Specify the input is a partial stream.
-        This option is deprecated and no longer does anything. It will be
-        removed in the future.
     :param bool subunit_out: Output the subunit stream to stdout
     :param str repo_type: This is the type of repository to use. Valid choices
         are 'file' and 'sql'.
@@ -184,10 +175,6 @@ def load(force_init=False, in_streams=None,
         for failures.
     :rtype: int
     """
-    if partial:
-        warnings.warn('The partial flag is deprecated and has no effect '
-                      'anymore')
-
     try:
         repo = util.get_repo_open(repo_type, repo_url)
     except repository.RepositoryNotFound:

--- a/stestr/config_file.py
+++ b/stestr/config_file.py
@@ -51,9 +51,9 @@ class TestrConf:
                         test_path=None, top_dir=None, group_regex=None,
                         repo_type='file', repo_url=None,
                         serial=False, worker_path=None,
-                        concurrency=0, blacklist_file=None,
-                        exclude_list=None, whitelist_file=None,
-                        include_list=None, black_regex=None,
+                        concurrency=0,
+                        exclude_list=None,
+                        include_list=None,
                         exclude_regex=None,
                         randomize=False, parallel_class=None):
         """Get a test_processor.TestProcessorFixture for this config file
@@ -89,16 +89,10 @@ class TestrConf:
             to use for the run.
         :param int concurrency: How many processes to use. The default (0)
             autodetects your CPU count and uses that.
-        :param str blacklist_file: Available now but soon to be replaced by the
-            new option exclude_list below.
         :param str exclude_list: Path to an exclusion list file, this
             file contains a separate regex exclude on each newline.
-        :param str whitelist_file: Available now but soon to be replaced by the
-            new option include_list below.
         :param str include_list: Path to an inclusion list file, this
             file contains a separate regex on each newline.
-        :param str black_regex: Available now but soon to be replaced by the
-            new option exclude_regex below.
         :param str exclude_regex: Test rejection regex. If a test cases name
             matches on re.search() operation, it will be removed from the final
             test list.
@@ -177,7 +171,6 @@ class TestrConf:
             test_ids, command, listopt, idoption, repository,
             test_filters=regexes, group_callback=group_callback, serial=serial,
             worker_path=worker_path, concurrency=concurrency,
-            blacklist_file=blacklist_file,
-            exclude_list=exclude_list, black_regex=black_regex,
-            exclude_regex=exclude_regex, whitelist_file=whitelist_file,
+            exclude_list=exclude_list,
+            exclude_regex=exclude_regex,
             include_list=include_list, randomize=randomize)

--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -88,19 +88,15 @@ def _get_regex_from_include_list(file_path):
     return lines
 
 
-def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
-                   regexes=None, black_regex=None, exclude_list=None,
+def construct_list(test_ids, regexes=None, exclude_list=None,
                    include_list=None, exclude_regex=None):
     """Filters the discovered test cases
 
     :param list test_ids: The set of test_ids to be filtered
-    :param str blacklist_file: Soon to be replaced by exclude_list
-    :param str whitelist_file: Soon to be replaced by include_list
     :param list regexes: A list of regex filters to apply to the test_ids. The
         output will contain any test_ids which have a re.search() match for any
         of the regexes in this list. If this is None all test_ids will be
         returned
-    :param str black_regex: Soon to be replaced by exclude_regex
     :param str exclude_list: The path to an exclusion_list file
     :param str include_list: The path to an inclusion_list file
     :param str exclude_regex: regex pattern to exclude tests
@@ -116,8 +112,6 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
     safe_re = None
     if include_list:
         safe_re = _get_regex_from_include_list(include_list)
-    elif whitelist_file:
-        safe_re = _get_regex_from_include_list(whitelist_file)
 
     if not regexes and safe_re:
         regexes = safe_re
@@ -126,8 +120,6 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
 
     if exclude_list:
         exclude_data = exclusion_reader(exclude_list)
-    elif blacklist_file:
-        exclude_data = exclusion_reader(blacklist_file)
     else:
         exclude_data = None
 
@@ -138,18 +130,6 @@ def construct_list(test_ids, blacklist_file=None, whitelist_file=None,
         except re.error:
             print("Invalid regex: %s used for exclude_regex" %
                   exclude_regex, file=sys.stderr)
-            sys.exit(5)
-        if exclude_data:
-            exclude_data.append(record)
-        else:
-            exclude_data = [record]
-    elif black_regex:
-        msg = "Skipped because of regexp provided as a command line argument:"
-        try:
-            record = (re.compile(black_regex), msg, [])
-        except re.error:
-            print("Invalid regex: %s used for black_regex" % black_regex,
-                  file=sys.stderr)
             sys.exit(5)
         if exclude_data:
             exclude_data.append(record)

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -68,12 +68,8 @@ class TestProcessorFixture(fixtures.Fixture):
         to use for the run
     :param int concurrency: How many processes to use. The default (0)
         autodetects your CPU count and uses that.
-    :param path blacklist_file: Available now but soon to be replaced by the
-        new option exclude_list below.
     :param path exclude_list: Path to an exclusion list file, this file
         contains a separate regex exclude on each newline.
-    :param str whitelist_file: Available now but soon to be replaced by the
-        new option include_list below.
     :param path include_list: Path to an inclusion list file, this file
          contains a separate regex on each newline.
     :param boolean randomize: Randomize the test order after they are
@@ -83,9 +79,9 @@ class TestProcessorFixture(fixtures.Fixture):
     def __init__(self, test_ids, cmd_template, listopt, idoption,
                  repository, parallel=True, listpath=None,
                  test_filters=None, group_callback=None, serial=False,
-                 worker_path=None, concurrency=0, blacklist_file=None,
-                 exclude_list=None, black_regex=None,
-                 exclude_regex=None, whitelist_file=None,
+                 worker_path=None, concurrency=0,
+                 exclude_list=None,
+                 exclude_regex=None,
                  include_list=None, randomize=False):
         """Create a TestProcessorFixture."""
 
@@ -103,11 +99,8 @@ class TestProcessorFixture(fixtures.Fixture):
         self.worker_path = None
         self.worker_path = worker_path
         self.concurrency_value = concurrency
-        self.blacklist_file = blacklist_file
         self.exclude_list = exclude_list
-        self.whitelist_file = whitelist_file
         self.include_list = include_list
-        self.black_regex = black_regex
         self.exclude_regex = exclude_regex
         self.randomize = randomize
 
@@ -124,9 +117,9 @@ class TestProcessorFixture(fixtures.Fixture):
 
         self.list_cmd = re.sub(variable_regex, list_subst, cmd)
         nonparallel = not self.parallel
-        selection_logic = (self.test_filters or self.blacklist_file or
-                           self.exclude_list or self.whitelist_file or
-                           self.include_list or self.black_regex or
+        selection_logic = (self.test_filters or
+                           self.exclude_list or
+                           self.include_list or
                            self.exclude_regex)
         if nonparallel:
             self.concurrency = 1
@@ -153,12 +146,9 @@ class TestProcessorFixture(fixtures.Fixture):
             idlist = ''
         else:
             self.test_ids = selection.construct_list(
-                self.test_ids, blacklist_file=self.blacklist_file,
-                exclude_list=self.exclude_list,
-                whitelist_file=self.whitelist_file,
+                self.test_ids, exclude_list=self.exclude_list,
                 include_list=self.include_list,
                 regexes=self.test_filters,
-                black_regex=self.black_regex,
                 exclude_regex=self.exclude_regex)
             name = self.make_listfile()
             variables['IDFILE'] = name

--- a/stestr/tests/test_config_file.py
+++ b/stestr/tests/test_config_file.py
@@ -60,12 +60,12 @@ class TestTestrConf(base.TestCase):
         # we specfied and with the correct python.
         mock_TestProcessorFixture.assert_called_once_with(
             None, command, "--list", "--load-list $IDFILE",
-            mock_get_repo_open.return_value, black_regex=None,
+            mock_get_repo_open.return_value,
             exclude_regex=None,
-            blacklist_file=None, exclude_list=None, concurrency=0,
+            exclude_list=None, concurrency=0,
             group_callback=expected_group_callback,
             test_filters=None, randomize=False, serial=False,
-            whitelist_file=None, include_list=None, worker_path=None)
+            include_list=None, worker_path=None)
 
     @mock.patch.object(config_file, 'sys')
     def _check_get_run_command_exception(self, mock_sys, platform='win32',

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -134,28 +134,12 @@ class TestReturnCodes(base.TestCase):
     def test_parallel_fails_unxsuccess(self):
         self.assertRunExit('stestr run unexpected', 1)
 
-    def test_parallel_blacklist(self):
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        with os.fdopen(fd, 'w') as blacklist:
-            blacklist.write('fail')
-        cmd = 'stestr run --blacklist-file %s' % path
-        self.assertRunExit(cmd, 0)
-
     def test_parallel_exclusion_list(self):
         fd, path = tempfile.mkstemp()
         self.addCleanup(os.remove, path)
         with os.fdopen(fd, 'w') as exclusion_list:
             exclusion_list.write('fail')
         cmd = 'stestr run --exclude-list %s' % path
-        self.assertRunExit(cmd, 0)
-
-    def test_parallel_whitelist(self):
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        with os.fdopen(fd, 'w') as whitelist:
-            whitelist.write('passing')
-        cmd = 'stestr run --whitelist-file %s' % path
         self.assertRunExit(cmd, 0)
 
     def test_parallel_inclusion_list(self):
@@ -172,28 +156,12 @@ class TestReturnCodes(base.TestCase):
     def test_serial_fails(self):
         self.assertRunExit('stestr run --serial', 1)
 
-    def test_serial_blacklist(self):
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        with os.fdopen(fd, 'w') as blacklist:
-            blacklist.write('fail')
-        cmd = 'stestr run --serial --blacklist-file %s' % path
-        self.assertRunExit(cmd, 0)
-
     def test_serial_exclusion_list(self):
         fd, path = tempfile.mkstemp()
         self.addCleanup(os.remove, path)
         with os.fdopen(fd, 'w') as exclusion_list:
             exclusion_list.write('fail')
         cmd = 'stestr run --serial --exclude-list %s' % path
-        self.assertRunExit(cmd, 0)
-
-    def test_serial_whitelist(self):
-        fd, path = tempfile.mkstemp()
-        self.addCleanup(os.remove, path)
-        with os.fdopen(fd, 'w') as whitelist:
-            whitelist.write('passing')
-        cmd = 'stestr run --serial --whitelist-file %s' % path
         self.assertRunExit(cmd, 0)
 
     def test_serial_inclusion_list(self):

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import io
-import os
 import re
 from unittest import mock
 
@@ -40,24 +39,6 @@ class TestSelection(base.TestCase):
 
 
 class TestExclusionReader(base.TestCase):
-    def test_black_reader(self):
-        blacklist_file = io.StringIO()
-        for i in range(4):
-            blacklist_file.write('fake_regex_%s\n' % i)
-            blacklist_file.write('fake_regex_with_note_%s # note\n' % i)
-        blacklist_file.seek(0)
-        with mock.patch('builtins.open',
-                        return_value=blacklist_file):
-            result = selection.exclusion_reader('fake_path')
-        self.assertEqual(2 * 4, len(result))
-        note_cnt = 0
-        # not assuming ordering, mainly just testing the type
-        for r in result:
-            self.assertEqual(r[2], [])
-            if r[1] == 'note':
-                note_cnt += 1
-            self.assertIn('search', dir(r[0]))  # like a compiled regexp
-        self.assertEqual(note_cnt, 4)
 
     def test_exclusion_reader(self):
         exclude_list = io.StringIO()
@@ -95,32 +76,10 @@ class TestConstructList(base.TestCase):
         result = selection.construct_list(test_lists, regexes=['foo'])
         self.assertEqual(list(result), ['fake_test(scen)[egg,foo])'])
 
-    def test_simple_black_re(self):
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
-        result = selection.construct_list(test_lists, black_regex='foo')
-        self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
-
     def test_simple_exclusion_re(self):
         test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
         result = selection.construct_list(test_lists, exclude_regex='foo')
         self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
-
-    def test_precedence_black_re_vs_exclude_re(self):
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
-        result = selection.construct_list(test_lists,
-                                          exclude_regex='foo',
-                                          black_regex='bar')
-        # When both options are used together, 'exclude_regex'
-        # is respected while 'black_regex' is ignored!
-        self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
-
-    def test_invalid_black_re(self):
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
-        invalid_regex = "fake_regex_with_bad_part[The-BAD-part]"
-        with mock.patch('sys.exit', side_effect=ImportError) as exit_mock:
-            self.assertRaises(ImportError, selection.construct_list,
-                              test_lists, black_regex=invalid_regex)
-            exit_mock.assert_called_once_with(5)
 
     def test_invalid_exclusion_re(self):
         test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
@@ -129,16 +88,6 @@ class TestConstructList(base.TestCase):
             self.assertRaises(ImportError, selection.construct_list,
                               test_lists, exclude_regex=invalid_regex)
             exit_mock.assert_called_once_with(5)
-
-    def test_blacklist(self):
-        black_list = [(re.compile('foo'), 'foo not liked', [])]
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
-        with mock.patch('stestr.selection.exclusion_reader',
-                        return_value=black_list):
-            result = selection.construct_list(test_lists,
-                                              blacklist_file='file',
-                                              regexes=['fake_test'])
-        self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
 
     def test_exclusion_list(self):
         exclude_list = [(re.compile('foo'), 'foo not liked', [])]
@@ -149,37 +98,6 @@ class TestConstructList(base.TestCase):
                                               exclude_list='file',
                                               regexes=['fake_test'])
         self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
-
-    def test_precedence_blacklist_vs_exclude_list(self):
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
-        # New option --exclude-list to be passed -> should be used
-        exclude_file = open('exclude_file.txt', 'w')
-        exclude_file.write("foo\nfoo not liked")
-        exclude_file.close()
-        # Old option --blacklist-file to be passed -> should be ignored
-        black_file = open('black_file.txt', 'w')
-        black_file.write("bar\nbar not liked")
-        black_file.close()
-
-        result = selection.construct_list(test_lists,
-                                          exclude_list='exclude_file.txt',
-                                          blacklist_file='black_file.txt',
-                                          regexes=['fake_test'])
-        self.assertEqual(list(result), ['fake_test(scen)[tag,bar])'])
-        # Cleanup
-        os.remove('exclude_file.txt')
-        os.remove('black_file.txt')
-
-    def test_whitelist(self):
-        white_list = [re.compile('fake_test1'), re.compile('fake_test2')]
-        test_lists = ['fake_test1[tg]', 'fake_test2[tg]', 'fake_test3[tg]']
-        white_getter = 'stestr.selection._get_regex_from_include_list'
-        with mock.patch(white_getter,
-                        return_value=white_list):
-            result = selection.construct_list(test_lists,
-                                              whitelist_file='file')
-        self.assertEqual(set(result),
-                         {'fake_test1[tg]', 'fake_test2[tg]'})
 
     def test_inclusion_list(self):
         include_list = [re.compile('fake_test1'), re.compile('fake_test2')]
@@ -192,35 +110,6 @@ class TestConstructList(base.TestCase):
         self.assertEqual(set(result),
                          {'fake_test1[tg]', 'fake_test2[tg]'})
 
-    def test_precedence_whitelist_vs_include_list(self):
-        test_lists = ['fake_test1[tg]', 'fake_test2[tg]', 'fake_test3[tg]']
-        # New option --include-list to be passed -> should be used
-        include_file = open('include_file.txt', 'w')
-        include_file.write('fake_test1\nfake_test2')
-        include_file.close()
-        # Old option --whitelist-file to be passed -> should be ignored
-        whitelist_file = open('whitelist_file.txt', 'w')
-        whitelist_file.write('fake_test3')
-        whitelist_file.close()
-
-        result = selection.construct_list(test_lists,
-                                          include_list='include_file.txt',
-                                          whitelist_file='whitelist_file.txt')
-        self.assertEqual({'fake_test1[tg]', 'fake_test2[tg]'}, set(result))
-        # Cleanup
-        os.remove('include_file.txt')
-        os.remove('whitelist_file.txt')
-
-    def test_whitelist_invalid_regex(self):
-        whitelist_file = io.StringIO()
-        whitelist_file.write("fake_regex_with_bad_part[The-BAD-part]")
-        whitelist_file.seek(0)
-        with mock.patch('builtins.open',
-                        return_value=whitelist_file):
-            with mock.patch('sys.exit') as mock_exit:
-                selection._get_regex_from_include_list('fake_path')
-                mock_exit.assert_called_once_with(5)
-
     def test_inclusion_list_invalid_regex(self):
         include_list = io.StringIO()
         include_list.write("fake_regex_with_bad_part[The-BAD-part]")
@@ -230,21 +119,6 @@ class TestConstructList(base.TestCase):
             with mock.patch('sys.exit') as mock_exit:
                 selection._get_regex_from_include_list('fake_path')
                 mock_exit.assert_called_once_with(5)
-
-    def test_whitelist_blacklist_re(self):
-        white_list = [re.compile('fake_test1'), re.compile('fake_test2')]
-        test_lists = ['fake_test1[tg]', 'fake_test2[spam]',
-                      'fake_test3[tg,foo]', 'fake_test4[spam]']
-        black_list = [(re.compile('spam'), 'spam not liked', [])]
-        white_getter = 'stestr.selection._get_regex_from_include_list'
-        with mock.patch(white_getter,
-                        return_value=white_list):
-            with mock.patch('stestr.selection.exclusion_reader',
-                            return_value=black_list):
-                result = selection.construct_list(test_lists, 'black_file',
-                                                  'white_file', ['foo'])
-        self.assertEqual(set(result),
-                         {'fake_test1[tg]', 'fake_test3[tg,foo]'})
 
     def test_inclusion_exclusion_list_re(self):
         include_list = [re.compile('fake_test1'), re.compile('fake_test2')]
@@ -257,28 +131,10 @@ class TestConstructList(base.TestCase):
             with mock.patch('stestr.selection.exclusion_reader',
                             return_value=exclude_list):
                 result = selection.construct_list(
-                    test_lists, 'exclude_file',
+                    test_lists, exclude_list='exclude_file',
                     include_list='include_file', regexes=['foo'])
         self.assertEqual(set(result),
                          {'fake_test1[tg]', 'fake_test3[tg,foo]'})
-
-    def test_overlapping_black_regex(self):
-
-        black_list = [(re.compile('compute.test_keypairs.KeypairsTestV210'),
-                       '', []),
-                      (re.compile('compute.test_keypairs.KeypairsTestV21'),
-                       '', [])]
-        test_lists = [
-            'compute.test_keypairs.KeypairsTestV210.test_create_keypair',
-            'compute.test_keypairs.KeypairsTestV21.test_create_keypair',
-            'compute.test_fake.FakeTest.test_fake_test']
-        with mock.patch('stestr.selection.exclusion_reader',
-                        return_value=black_list):
-            result = selection.construct_list(test_lists,
-                                              blacklist_file='file',
-                                              regexes=['fake_test'])
-        self.assertEqual(
-            list(result), ['compute.test_fake.FakeTest.test_fake_test'])
 
     def test_overlapping_exclude_regex(self):
 


### PR DESCRIPTION
In preparation for the stestr 4.0.0 release this commit removes the
deprecated command line options. This includes '--whitelist-file',
'--blacklist-file', '--black-regex' and '--partial'. The selection
options have been deprecated for > 1 year and the '--partial' option has
been deprecated > 4 years and hasn't had any effect in that time. The
4.0.0 release will be primarily to make these deprecation removals
(along with the sql repository type which will be in a separate commit).