### PR TITLE
Add Python 3.10 support and drop 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,18 +15,18 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
 project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-python_requires = >=3.5
+python_requires = >=3.6
 
 [files]
 packages =

--- a/stestr/tests/files/tox.ini
+++ b/stestr/tests/files/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py38,py37,py36,py35,pep8
+envlist = py310,py39,py38,py37,py36,pep8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py38,py37,py36,py35,pep8
+envlist = py310,py39,py38,py37,py36,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit adds Python 3.10 support and drop 3.5 at the same time. We
should support the latest release version as possible. And, we can drop
the 3.5 because the version is already EOL for more than 1.5 years[1].

[1] https://www.python.org/downloads/release/python-3510/