### PR TITLE
Add destructor to wait for process termination

### DIFF
--- a/stestr/output.py
+++ b/stestr/output.py
@@ -171,6 +171,9 @@ class ReturnCodeToSubunit:
         self.source = self.proc.stdout
         self.lastoutput = bytes((b'\n')[0])
 
+    def __del__(self):
+        self.proc.wait()
+
     def _append_return_code_as_test(self):
         if self.done is True:
             return


### PR DESCRIPTION
This commit adds a destructor to wait for a process termination in
`ReturnCodeToSubunit` class. This commit fixes #320 partially.