### PR TITLE
Update IRC network for stestr channel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,6 @@ Community
 
 Besides Github interactions there is also a stestr IRC channel:
 
-#stestr on Freenode
+#stestr on `OFTC <https://oftc.net/>`__
 
 feel free to join to ask questions, or just discuss stestr.


### PR DESCRIPTION
We migrated the stestr IRC channel off of Freenode some time ago but
never updated the README to reflect it now lives in OFTC. This commit
corrects this oversight so people who are interested in joining the
channel will be able to find it.