### PR TITLE
Add coverxml task and cover job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.10
       - name: Pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,36 @@ jobs:
         run: python -m pip install -U tox
       - name: Run lint
         run: tox -epep8
+  cover:
+    name: cover
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-lint-
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+            ${{ runner.os }}-${{ matrix.python-version }}-
+      - name: Install Deps
+        run: python -m pip install -U tox
+      - name: Run coverxml
+        run: tox -ecoverxml
+      - name: codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./cover/coverage.xml # optional
+          flags: unittests # optional
+          name: stestr # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
   docs:
     name: docs
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,15 @@ commands =
     coverage combine
     coverage html -d cover
 
+[testenv:coverxml]
+setenv =
+    VIRTUAL_ENV={envdir}
+    PYTHON=coverage run --source stestr
+commands =
+    coverage run stestr/cli.py run {posargs}
+    coverage combine
+    coverage xml -o cover/coverage.xml
+
 [testenv:docs]
 extras =
   sql


### PR DESCRIPTION
This commit adds coverxml task to tox.ini and cover job to main.yml to
enable coverage tracking. We already have it in travis.yml but it seems
it hasn't worked recently. And, it's a good timing to migrate to GitHub
Actions if it works well because we can remove travis.yml just only for
tracking the coverage.