### PR TITLE
Fix #330 - Preserve load-list order

### DIFF
--- a/stestr/selection.py
+++ b/stestr/selection.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import contextlib
+import random
 import re
 import sys
 
@@ -89,7 +90,7 @@ def _get_regex_from_include_list(file_path):
 
 
 def construct_list(test_ids, regexes=None, exclude_list=None,
-                   include_list=None, exclude_regex=None):
+                   include_list=None, exclude_regex=None, randomize=False):
     """Filters the discovered test cases
 
     :param list test_ids: The set of test_ids to be filtered
@@ -100,10 +101,11 @@ def construct_list(test_ids, regexes=None, exclude_list=None,
     :param str exclude_list: The path to an exclusion_list file
     :param str include_list: The path to an inclusion_list file
     :param str exclude_regex: regex pattern to exclude tests
+    :param str randomize: Randomize the result
 
     :return: iterable of strings. The strings are full
         test_ids
-    :rtype: set
+    :rtype: list
     """
 
     if not regexes:
@@ -137,20 +139,16 @@ def construct_list(test_ids, regexes=None, exclude_list=None,
             exclude_data = [record]
 
     list_of_test_cases = filter_tests(regexes, test_ids)
-    set_of_test_cases = set(list_of_test_cases)
 
-    if not exclude_data:
-        return set_of_test_cases
+    if exclude_data:
+        # NOTE(afazekas): We might use a faster logic when the
+        # print option is not requested
+        for (rex, msg, s_list) in exclude_data:
+            # NOTE(mtreinish): In the case of overlapping regex the test case
+            # might have already been removed from the set of tests
+            list_of_test_cases = [tc for tc in list_of_test_cases
+                                  if not rex.search(tc)]
+    if randomize:
+        random.shuffle(list_of_test_cases)
 
-    # NOTE(afazekas): We might use a faster logic when the
-    # print option is not requested
-    for (rex, msg, s_list) in exclude_data:
-        for test_case in list_of_test_cases:
-            if rex.search(test_case):
-                # NOTE(mtreinish): In the case of overlapping regex the test
-                # case might have already been removed from the set of tests
-                if test_case in set_of_test_cases:
-                    set_of_test_cases.remove(test_case)
-                    s_list.append(test_case)
-
-    return set_of_test_cases
+    return list_of_test_cases

--- a/stestr/test_processor.py
+++ b/stestr/test_processor.py
@@ -96,7 +96,6 @@ class TestProcessorFixture(fixtures.Fixture):
         self._listpath = listpath
         self.test_filters = test_filters
         self._group_callback = group_callback
-        self.worker_path = None
         self.worker_path = worker_path
         self.concurrency_value = concurrency
         self.exclude_list = exclude_list
@@ -145,11 +144,14 @@ class TestProcessorFixture(fixtures.Fixture):
             name = ''
             idlist = ''
         else:
+            # Randomize now if it's not going to be partitioned
+            randomize = self.randomize and self.concurrency == 1
             self.test_ids = selection.construct_list(
                 self.test_ids, exclude_list=self.exclude_list,
                 include_list=self.include_list,
                 regexes=self.test_filters,
-                exclude_regex=self.exclude_regex)
+                exclude_regex=self.exclude_regex,
+                randomize=randomize)
             name = self.make_listfile()
             variables['IDFILE'] = name
             idlist = ' '.join(self.test_ids)

--- a/stestr/tests/subunit_runner/test_program.py
+++ b/stestr/tests/subunit_runner/test_program.py
@@ -1,0 +1,124 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from stestr.subunit_runner import program
+from stestr.tests import base
+
+
+class TestGetById(base.TestCase):
+    class CompatibleSuite(unittest.TestSuite):
+        def filter_by_ids(self, test_ids):
+            return unittest.TestSuite([item for item in self
+                                       if item.id() in test_ids])
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_suite = unittest.TestSuite([cls(name) for name in dir(cls)
+                                             if name.startswith('test')])
+
+    @classmethod
+    def _test_name(cls, name):
+        return f'{__name__}.{cls.__name__}.{name}'
+
+    @staticmethod
+    def _test_ids(suite):
+        return [item.id() for item in suite]
+
+    def test_filter_by_ids_case_no_tests(self):
+        test_case = type(self)('test_filter_by_ids_case_no_tests')
+        result = program.filter_by_ids(test_case, [
+            'stestr.tests.test_load.TestLoadCommand.test_empty_with_pretty_out'
+        ])
+        self.assertEqual([], self._test_ids(result))
+
+    def test_filter_by_ids_case_simple(self):
+        name = 'test_filter_by_ids_case_simple'
+        test_name = self._test_name(name)
+        test_case = type(self)(name)
+        result = program.filter_by_ids(test_case, [test_name])
+        self.assertEqual([test_name], self._test_ids(result))
+
+    def test_filter_by_ids_suite_no_tests(self):
+        result = program.filter_by_ids(self.test_suite, [
+            'stestr.tests.test_load.TestLoadCommand.test_empty_with_pretty_out'
+        ])
+        self.assertEqual([], self._test_ids(result))
+
+    def test_filter_by_ids_suite_simple(self):
+        test_name = self._test_name('test_filter_by_ids_suite_simple')
+        result = program.filter_by_ids(self.test_suite, [test_name])
+        self.assertEqual([test_name], self._test_ids(result))
+
+    def test_filter_by_ids_suite_preserves_order(self):
+        names = ('test_filter_by_ids_suite_simple',
+                 'test_filter_by_ids_suite_preserves_order',
+                 'test_filter_by_ids_suite_no_tests')
+        test_names = [self._test_name(name) for name in names]
+        result = program.filter_by_ids(self.test_suite, test_names)
+        self.assertEqual(test_names, self._test_ids(result))
+
+    def test_filter_by_ids_suite_no_duplicates(self):
+        names = ('test_filter_by_ids_suite_simple',
+                 'test_filter_by_ids_suite_preserves_order')
+        expected = [self._test_name(name) for name in names]
+        # Create duplicates in reversed order
+        test_names = expected + expected[::-1]
+        result = program.filter_by_ids(self.test_suite, test_names)
+        self.assertEqual(expected, self._test_ids(result))
+
+    def test_filter_by_ids_compatible_no_tests(self):
+        test_suite = self.CompatibleSuite(self.test_suite)
+        result = program.filter_by_ids(test_suite, [
+            'stestr.tests.test_load.TestLoadCommand.test_empty_with_pretty_out'
+        ])
+        self.assertEqual([], self._test_ids(result))
+
+    def test_filter_by_ids_compatible_simple(self):
+        test_suite = self.CompatibleSuite(self.test_suite)
+        test_name = self._test_name('test_filter_by_ids_compatible_simple')
+        result = program.filter_by_ids(test_suite, [test_name])
+        self.assertEqual([test_name], self._test_ids(result))
+
+    def test_filter_by_ids_compatible_preserves_order(self):
+        test_suite = self.CompatibleSuite(self.test_suite)
+        names = ('test_filter_by_ids_compatible_simple',
+                 'test_filter_by_ids_compatible_preserves_order',
+                 'test_filter_by_ids_compatible_no_tests')
+        test_names = [self._test_name(name) for name in names]
+        result = program.filter_by_ids(test_suite, test_names)
+        self.assertEqual(test_names, self._test_ids(result))
+
+    def test_filter_by_ids_compatible_no_duplicates(self):
+        test_suite = self.CompatibleSuite(self.test_suite)
+        names = ('test_filter_by_ids_compatible_simple',
+                 'test_filter_by_ids_compatible_preserves_order')
+        expected = [self._test_name(name) for name in names]
+        # Create duplicates in reversed order
+        test_names = expected + expected[::-1]
+        result = program.filter_by_ids(test_suite, test_names)
+        self.assertEqual(expected, self._test_ids(result))
+
+    def test_filter_by_ids_no_duplicates_preserve_order(self):
+        test_suite = unittest.TestSuite(
+            [self.CompatibleSuite(self.test_suite),
+             self.test_suite,
+             type(self)('test_filter_by_ids_no_duplicates_preserve_order')])
+        names = ('test_filter_by_ids_compatible_simple',
+                 'test_filter_by_ids_suite_simple',
+                 'test_filter_by_ids_compatible_preserves_order')
+        expected = [self._test_name(name) for name in names]
+        # Create duplicates in reversed order
+        test_names = expected + expected[::-1]
+        result = program.filter_by_ids(test_suite, test_names)
+        self.assertEqual(expected, self._test_ids(result))

--- a/stestr/tests/test_load.py
+++ b/stestr/tests/test_load.py
@@ -13,11 +13,14 @@
 import io
 
 from stestr.commands import load
+from stestr import subunit_trace
 from stestr.tests import base
 
 
 class TestLoadCommand(base.TestCase):
     def test_empty_with_pretty_out(self):
+        # Clear results that may be there
+        subunit_trace.RESULTS.clear()
         stream = io.BytesIO()
         output = io.BytesIO()
         res = load.load(in_streams=[('subunit', stream)], pretty_out=True,

--- a/stestr/tests/test_run.py
+++ b/stestr/tests/test_run.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import io
+from unittest import mock
 
 from stestr.commands import run
 from stestr.tests import base
@@ -46,3 +47,55 @@ class TestRunCommand(base.TestCase):
             'Using 0.\n')
         self.assertEqual(fake_stderr.getvalue(), expected)
         self.assertEqual(0, out)
+
+
+class TestLoadListAndFilter(base.TestCase):
+    @mock.patch('builtins.open', side_effect=FileNotFoundError)
+    def test__load_list_and_filter_file_not_found(self, mock_open):
+        filename = 'my_filename'
+        self.assertRaises(FileNotFoundError,
+                          run._load_list_and_filter, filename, None)
+
+        mock_open.assert_called_once_with(filename, 'rb')
+        mock_open.return_value.__enter__.return_value.read.assert_not_called()
+
+    @mock.patch('builtins.open')
+    def test__load_list_and_filter_empty_file(self, mock_open):
+        mock_read = mock_open.return_value.__enter__.return_value.read
+        mock_read.return_value = b''
+        filename = 'my_filename'
+        res = run._load_list_and_filter(filename, ['mytest'])
+        self.assertListEqual([], res)
+        mock_open.assert_called_once_with(filename, 'rb')
+        mock_read.assert_called_once_with()
+
+    @mock.patch('builtins.open')
+    def test__load_list_and_filter_no_filter(self, mock_open):
+        mock_read = mock_open.return_value.__enter__.return_value.read
+        tests = ['test1', 'tests2', 'test3']
+        mock_read.return_value = '\n'.join(tests).encode()
+        filename = 'my_filename'
+
+        res = run._load_list_and_filter(filename, None)
+
+        self.assertListEqual(tests, res)
+        mock_open.assert_called_once_with(filename, 'rb')
+        mock_read.assert_called_once_with()
+
+    @mock.patch('builtins.open')
+    def test__load_list_and_filter_filter(self, mock_open):
+        mock_read = mock_open.return_value.__enter__.return_value.read
+        tests = ['test1', 'tests2', 'test3']
+        mock_read.return_value = '\n'.join(tests).encode()
+        filename = 'my_filename'
+
+        # Failed tests in different order from list and with additional ids to
+        # confirm that order from list is preserved and only elements from list
+        # are returned
+        failed_tests = ['test4', 'test3', 'test1']
+        expected = ['test1', 'test3']
+        res = run._load_list_and_filter(filename, failed_tests)
+
+        self.assertListEqual(expected, res)
+        mock_open.assert_called_once_with(filename, 'rb')
+        mock_read.assert_called_once_with()

--- a/stestr/tests/test_selection.py
+++ b/stestr/tests/test_selection.py
@@ -72,9 +72,28 @@ class TestExclusionReader(base.TestCase):
 
 class TestConstructList(base.TestCase):
     def test_simple_re(self):
-        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']
+        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])',
+                      'fake_test(necs)[tag,bar])', 'fake_test(necs)[egg,foo])',
+                      'fake_test(nnnn)[foo,bar])', 'fake_test(nnnn)[foo,foo])']
         result = selection.construct_list(test_lists, regexes=['foo'])
-        self.assertEqual(list(result), ['fake_test(scen)[egg,foo])'])
+        # Order must be preserved
+        expected = test_lists[:]
+        del expected[2]
+        del expected[0]
+        self.assertEqual(expected, result)
+
+    def test_simple_re_randomized(self):
+        test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])',
+                      'fake_test(necs)[tag,bar])', 'fake_test(necs)[egg,foo])',
+                      'fake_test(nnnn)[foo,bar])', 'fake_test(nnnn)[foo,foo])']
+        result = selection.construct_list(test_lists, regexes=['foo'],
+                                          randomize=True)
+        expected_names = test_lists[:]
+        del expected_names[2]
+        del expected_names[0]
+        # Order is randomized
+        self.assertNotEqual(expected_names, result)
+        self.assertEqual(set(expected_names), set(result))
 
     def test_simple_exclusion_re(self):
         test_lists = ['fake_test(scen)[tag,bar])', 'fake_test(scen)[egg,foo])']


### PR DESCRIPTION
When using `--load-list` to run tests the tests were always run in a different order than the one provided in the file, even when the `--random` argument was not present:

```
  $ stestr run --serial --load-list failing
```

This patch preserves the order of the tests from the file when `--load-list` is used, and it will only randomize it when `--random` is provided:

```
  $ stestr run --serial --random --load-list failing
```