### PR TITLE
Reuse subunit_trace output/validation logic for load/run

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -359,14 +359,13 @@ def _load_case(
                     continue
                 start_times.append(test["timestamps"][0])
                 stop_times.append(test["timestamps"][1])
-        if not start_times or not stop_times:
-            sys.stderr.write("\nNo tests were successful during the run")
+
+        # This is not ideal, as it means if you use don't enter this if statement
+        # some errors aren't caught
+        if subunit_trace.print_full_output(
+            stdout, start_times, stop_times, post_fails=True, no_summary=False
+        ):
             return 1
-        start_time = min(start_times)
-        stop_time = max(stop_times)
-        elapsed_time = stop_time - start_time
-        subunit_trace.print_fails(stdout)
-        subunit_trace.print_summary(stdout, elapsed_time)
     if not results.wasSuccessful(summary_result):
         return 1
     else:

--- a/stestr/subunit_trace.py
+++ b/stestr/subunit_trace.py
@@ -265,11 +265,7 @@ def show_outcome(
 
 
 def print_fails(stream):
-    """Print summary failure report.
-
-    Currently unused, however there remains debate on inline vs. at end
-    reporting, so leave the utility function for later use.
-    """
+    """Print summary failure report."""
     if not FAILS:
         return
     stream.write("\n==============================\n")
@@ -470,16 +466,21 @@ def trace(
             for x in RESULTS[worker]
             if x["timestamps"][1] is not None
         ]
-    if not start_times:
+    if print_full_output(stdout, start_times, stop_times, post_fails, no_summary):
+        return 1
+    return 0 if results.wasSuccessful(summary) else 1
+
+
+def print_full_output(stdout, start_times, stop_times, post_fails, no_summary):
+    """Print output plus edge case validation"""
+    if not start_times or count_tests("status", ".*") == 0:
         print("The test run didn't actually run any tests", file=sys.stderr)
         return 1
+
     start_time = min(start_times)
     stop_time = max(stop_times)
     elapsed_time = stop_time - start_time
 
-    if count_tests("status", ".*") == 0:
-        print("The test run didn't actually run any tests", file=sys.stderr)
-        return 1
     if post_fails:
         print_fails(stdout)
     if not no_summary:
@@ -487,7 +488,7 @@ def trace(
 
     # NOTE(mtreinish): Ideally this should live in testtools streamSummary
     # this is just in place until the behavior lands there (if it ever does)
-    if count_tests("status", "^success$") == 0:
+    if count_tests("status", "^xfail$") + count_tests("status", "^success$") == 0:
         print("\nNo tests were successful during the run", file=sys.stderr)
         return 1
     in_progress = get_stuck_in_progress()
@@ -500,7 +501,6 @@ def trace(
         for test in in_progress:
             print("\n\t* %s" % test, file=sys.stderr)
         return 1
-    return 0 if results.wasSuccessful(summary) else 1
 
 
 def main():


### PR DESCRIPTION
Previously `stestr run` and subunit_trace used slightly different output and validation logic. run wouldn't catch the case where a test exited without a status, while code using `last` and `history` would since they used subunit_trace.

Refactor the subunit_trace output and validation logic and use it for `load`/`run`.

Converge on the subunit_trace formatted output, in addition to the summary also show if something goes wrong.

The primary motivation for this change is to better detect when a subprocess is killed and not all tests are run as expected (segfault, OOM etc.).