### PR TITLE
Reuse subunit_trace output logic for load/run

### DIFF
--- a/stestr/commands/load.py
+++ b/stestr/commands/load.py
@@ -278,16 +278,15 @@ def _load_case(inserter, repo, case, subunit_out, pretty_out,
             for test in subunit_trace.RESULTS[worker]:
                 if not test['timestamps'][0] or not test['timestamps'][1]:
                     continue
-                start_times.append(test['timestamps'][0])
-                stop_times.append(test['timestamps'][1])
-        if not start_times or not stop_times:
-            sys.stderr.write("\nNo tests were successful during the run")
+                start_times.append(test["timestamps"][0])
+                stop_times.append(test["timestamps"][1])
+
+        # This is not ideal, as it means if you use don't enter this if statement
+        # some errors aren't caught
+        if subunit_trace.print_full_output(
+            stdout, start_times, stop_times, post_fails=True, no_summary=False
+        ):
             return 1
-        start_time = min(start_times)
-        stop_time = max(stop_times)
-        elapsed_time = stop_time - start_time
-        subunit_trace.print_fails(stdout)
-        subunit_trace.print_summary(stdout, elapsed_time)
     if not results.wasSuccessful(summary_result):
         return 1
     else:


### PR DESCRIPTION
Previously `stestr run` and subunit_trace used slightly different output and validation logic. run wouldn't catch the case where a test exited without a status, while code using `last` and `history` would since they used subunit_trace.

Refactor the subunit_trace output and validation logic and use it for `load`/`run`.

Converge on the subunit_trace formatted output, in addition to the summary also show if something goes wrong.

The primary motivation for this change is to better detect when a subprocess is killed and not all tests are run as expected (segfault, OOM etc.).

Backported from #333