### PR TITLE
Remove vestigial future package from requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run lint
         run: tox -epep8
   cover:
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run coverxml
         run: tox -ecoverxml
       - name: codecov
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-future
 pbr!=2.1.0,>=2.0.0,!=4.0.0,!=4.0.1,!=4.0.2,!=4.0.3 # Apache-2.0
 cliff>=2.8.0 # Apache-2.0
 python-subunit>=1.4.0 # Apache-2.0/BSD

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,11 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
 project_urls =

--- a/stestr/repository/file.py
+++ b/stestr/repository/file.py
@@ -19,7 +19,7 @@ import os
 import sys
 import tempfile
 
-from future.moves.dbm import dumb as my_dbm
+from dbm import dumb as my_dbm
 from subunit import TestProtocolClient
 import subunit.v2
 import testtools

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py310,py39,py38,py37,py36,pep8
+envlist = py311,py310,py39,py38,py37,pep8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,9 @@ skipsdist = True
 usedevelop = True
 install_command = pip install -U --force-reinstall {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
-whitelist_externals = find
+allowlist_externals =
+    find
+    stestr
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
This package appears to be a holdover from dropping Python 2.x support, and is no longer needed.

This resolves https://nvd.nist.gov/vuln/detail/CVE-2022-40899

Also update tox.ini to work wirth modern vintages of tox.