### PR TITLE
Adding another prefix to the existing list of unittest_import_strs

### DIFF
--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -106,6 +106,7 @@ def list_test(test):
         "unittest2.loader.ModuleImportFailure.",
         "unittest.loader.ModuleImportFailure.",
         "discover.ModuleImportFailure.",
+        "unittest.loader._FailedTest.",
     }
     test_ids = []
     errors = []


### PR DESCRIPTION
Based on the `test.id` format found at [id](https://github.com/python/cpython/blob/53d9cd95cd91f1a291a3923acb95e0e86942291a/Lib/unittest/case.py#L500) for those test module's throwing `ImportError` exceptions [logic](https://github.com/python/cpython/blob/53d9cd95cd91f1a291a3923acb95e0e86942291a/Lib/unittest/loader.py#L38)... the prefix for these tests would be `unittest.loader._FailedTest`

__Snippet__
```
(py311) [stack@osp-devstack-03 tempest]$ python -m stestr.subunit_runner.run discover -t "./" "./tempest/test_discover" --list

unittest.loader._FailedTest.cinder_tempest_plugin.api.volume.test_volume_revert

import errorsB�Failed to import test module: cinder_tempest_plugin.api.volume.test_volume_revert
Traceback (most recent call last):
  File "/usr/lib64/python3.11/unittest/loader.py", line 407, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/unittest/loader.py", line 350, in _get_module_from_name
    __import__(name)
  File "/opt/stack/tempest/.tox/py311/lib/python3.11/site-packages/cinder_tempest_plugin/api/volume/test_volume_revert.py", line 19, in <module>
    from tempest.lib import exception
ImportError: cannot import name 'exception' from 'tempest.lib' (/opt/stack/tempest/tempest/lib/__init__.py)

```

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>