### PR TITLE
Fix ResourceWarning from SubunitTestRunner._list()

### DIFF
--- a/stestr/subunit_runner/run.py
+++ b/stestr/subunit_runner/run.py
@@ -14,7 +14,6 @@
 # under the License.
 
 from functools import partial
-import os
 import sys
 
 from subunit import StreamResultToBytes
@@ -71,14 +70,7 @@ class SubunitTestRunner(object):
 
     def _list(self, test):
         test_ids, errors = program.list_test(test)
-        try:
-            fileno = self.stream.fileno()
-        except Exception:
-            fileno = None
-        if fileno is not None:
-            stream = os.fdopen(fileno, "wb", 0)
-        else:
-            stream = self.stream
+        stream = self.stream
         result = StreamResultToBytes(stream)
         for test_id in test_ids:
             result.status(test_id=test_id, test_status="exists")


### PR DESCRIPTION
This commit fixes the ResourceWarning emitted by stestr's SubunitRunner._list method caused by a leaking file descriptor when that method exits. The root cause of this was this method was calling fdopen() internally to open a new descriptor to the user specified result stream and never closing it when the method returns. The issue was that the return from that method had a reference to that fd and closing it would have resulted in potentially unexpected behavior. However, this code is not needed, it was just ported from subunit's SubunitTestRunner class when this code was forked and rewritten to use unittest instead of testtools. The subunit code is used in a broader context and the fdopen might be needed there. But for stestr, we always use stdout for the result stream as this only gets called internally the worker processes to run tests. If we used something other than stdout the result stream would not get sent to the parent process. Since we're alwwys using stdout we don't need an fdopen call because we never will need a fresh fd for it. This commit removes the legacy baggage causing this ResourceWarning and just interacts with the stream directly avoiding an additional open that never gets closed.

Related to #320