### PR TITLE
Pin black to 2022 version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,4 @@ sphinx>2.1.0 # BSD
 coverage>=4.0 # Apache-2.0
 ddt>=1.0.1 # MIT
 doc8>=0.8.0 # Apache-2.0
-black>=22.8.0
+black~=22.0


### PR DESCRIPTION
Black only provides backwards compatibility guarantees for each year's versions. The major version is the year which will not make any breaking format changes in that release. Since we're in 2023 now black has released a 23.x.y release which causes incompatible changes with our previously used 22.x.y version. In the short term to avoid failures caused by these unrelated changes this commit pins our version to 22.x.y. In the future we can upgrade this version and update the formatting with the new rules at that time.