### PR TITLE
Update docs job to avoid setup.py entrypoint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ extras =
   sql
 commands =
   doc8 -e .rst doc/source CONTRIBUTING.rst README.rst
-  python setup.py build_sphinx
+  sphinx-build -W -T --keep-going -b html doc/source doc/build/html
 
 [testenv:releasenotes]
 commands = sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html


### PR DESCRIPTION
The docs builds were previously configured to use PBR's sphinx entrypoint. However, in newer versions of PBR that no longer exists and the docs builds are failing. This commit updates the tox job to just directly call sphinx-build to fix the docs builds locally and in CI.