### PR TITLE
Bugfix: make repo initialization respect pyproject.toml

### DIFF
--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -12,7 +12,6 @@
 
 """Run a projects tests and load them into stestr."""
 
-import configparser
 import errno
 import functools
 import io
@@ -470,29 +469,15 @@ def run_command(
         repo = util.get_repo_open(repo_url=repo_url)
     # If a repo is not found, and there a stestr config exists just create it
     except repository.RepositoryNotFound:
-        if not os.path.isfile(config) and not test_path:
-            # If there is no config and no test-path
-            if os.path.isfile("tox.ini"):
-                tox_conf = configparser.ConfigParser()
-                tox_conf.read("tox.ini")
-                if not tox_conf.has_section("stestr"):
-                    msg = (
-                        "No file found, --test-path not specified, and "
-                        "stestr section not found in tox.ini. Either "
-                        "create or specify a .stestr.conf, use "
-                        "--test-path, or add an stestr section to the "
-                        "tox.ini"
-                    )
-                    stdout.write(msg)
-                    exit(1)
-            else:
-                msg = (
-                    "No config file found and --test-path not specified. "
-                    "Either create or specify a .stestr.conf or use "
-                    "--test-path "
-                )
-                stdout.write(msg)
-                exit(1)
+        conf = config_file.TestrConf.load_from_file(config)
+        if not conf.test_path and not test_path:
+            msg = (
+                "No config file found and --test-path not specified. "
+                "Either create or specify a .stestr.conf, tox.ini, "
+                "or pyproject.toml, or use --test-path"
+            )
+            stdout.write(msg)
+            exit(1)
         try:
             repo = util.get_repo_initialise(repo_url=repo_url)
         except OSError as e:

--- a/stestr/tests/files/conf.toml
+++ b/stestr/tests/files/conf.toml
@@ -1,0 +1,3 @@
+[tool.stestr]
+test_path = './tests'
+group_regex = '([^\.]*\.)*'

--- a/stestr/tests/test_return_codes.py
+++ b/stestr/tests/test_return_codes.py
@@ -508,3 +508,19 @@ class TestReturnCodesToxIni(TestReturnCodes):
         tox_file = os.path.join(self.repo_root, "stestr/tests/files/tox.ini")
         shutil.copy(tox_file, self.tox_ini_dir)
         os.remove(self.testr_conf_file)
+
+
+class TestReturnCodesTOML(TestReturnCodes):
+    def setUp(self):
+        super().setUp()
+        self.pyproject_toml = os.path.join(self.directory, "pyproject.toml")
+        toml_conf = os.path.join(self.repo_root, "stestr/tests/files/conf.toml")
+        shutil.copy(toml_conf, self.pyproject_toml)
+        os.remove(self.testr_conf_file)
+
+    def test_all_configs_missing(self):
+        stestr_repo_dir = os.path.join(self.directory, ".stestr")
+        shutil.rmtree(stestr_repo_dir, ignore_errors=True)
+        os.remove(self.pyproject_toml)
+        output, _ = self.assertRunExit("stestr run passing", 1)
+        self.assertIn(b"No config file found", output)


### PR DESCRIPTION
Make the repo initialization step look for all supported config formats before giving up.

Fixes: Issue #351