### PR TITLE
[WIP] Add pytest runner mode

### DIFF
--- a/doc/source/MANUAL.rst
+++ b/doc/source/MANUAL.rst
@@ -68,6 +68,7 @@ A full example config file is::
   test_path=./project/tests
   top_dir=./
   group_regex=([^\.]*\.)*
+  runner=pytest
 
 
 The ``group_regex`` option is used to specify is used to provide a scheduler
@@ -77,7 +78,10 @@ You can also specify the ``parallel_class=True`` instead of
 group_regex to group tests in the stestr scheduler together by
 class. Since this is a common use case this enables that without
 needing to memorize the complicated regex for ``group_regex`` to do
-this.
+this. The ``runner`` argument is used to specify the test runner to use. By
+default a runner based on Python's standard library ``unittest`` module is
+used. However, if you'd prefer to use ``pytest`` as your runner you can specify
+this as the runner argument in the config file.
 
 There is also an option to specify all the options in the config file via the
 CLI. This way you can run stestr directly without having to write a config file
@@ -137,6 +141,8 @@ providing configs in TOML format, the configuration directives
 **must** be located in a ``[tool.stestr]`` section, and the filename
 **must** have a ``.toml`` extension.
 
+
+
 Running tests
 -------------
 
@@ -165,6 +171,28 @@ Additionally you can specify a specific class or method within that file using
 
 will skip discovery and directly call the test runner on the test method in the
 specified test class.
+
+Test runners
+''''''''''''
+
+By default ``stestr`` is built to run tests leveraging the Python standard
+library ``unittest`` modules runner. stestr includes a test runner that will
+emit the subunit protocol it relies on internally to handle live results from
+parallel workers. However, there is an alternative runner available that
+leverages ``pytest`` which is a popular test runner and testing library
+alternative to the standard library's ``unittest`` module. The ``stestr``
+project bundles a ``pytest`` plugin that adds real time subunit output to
+pytest. As a test suite author the ``pytest`` plugin enables you to write your
+test suite using pytest's test library instead of ``unittest``. There are two
+ways to specify your test runner, first is the ``--pytest`` flag on
+``stestr run``. This tells stestr for this test run use ``pytest`` as the runner
+instead of ``unittest``, this is good for a/b comparisons between the test
+runners and also general investigations with using different test runners. The
+other option is to leverage your project's config file and set the ``runner``
+field to either ``pytest`` or ``unittest`` (although ``unittest`` is always the
+default so you shouldn't ever need to set it). This is the more natural fit
+because if your test suite is written using pytest it won't be compatible with
+the unittest based runner.
 
 Running with pdb
 ''''''''''''''''

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PyYAML>=3.10.0 # MIT
 voluptuous>=0.8.9 # BSD License
 tomlkit>=0.11.6 # MIT
 extras>=1.0.0
+pytest>=2.3 # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ stestr.cm =
     history_list = stestr.commands.history:HistoryList
     history_show = stestr.commands.history:HistoryShow
     history_remove = stestr.commands.history:HistoryRemove
+pytest11 =
+    stestr_subunit = stestr.pytest_subunit
 
 [extras]
 sql =

--- a/stestr/commands/run.py
+++ b/stestr/commands/run.py
@@ -244,6 +244,12 @@ class Run(command.Command):
             help="If set, show non-text attachments. This is "
             "generally only useful for debug purposes.",
         )
+        parser.add_argument(
+            "--pytest",
+            action="store_true",
+            dest="pytest",
+            help="If set to True enable using pytest as the test runner",
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -335,6 +341,7 @@ class Run(command.Command):
             all_attachments=all_attachments,
             show_binary_attachments=args.show_binary_attachments,
             pdb=args.pdb,
+            pytest=args.pytest,
         )
 
         # Always output slowest test info if requested, regardless of other
@@ -396,6 +403,7 @@ def run_command(
     all_attachments=False,
     show_binary_attachments=True,
     pdb=False,
+    pytest=False,
 ):
     """Function to execute the run command
 
@@ -460,6 +468,8 @@ def run_command(
     :param str pdb: Takes in a single test_id to bypasses test
         discover and just execute the test specified without launching any
         additional processes. A file name may be used in place of a test name.
+    :param bool pytest: Set to true to use pytest as the test runner instead of
+        the stestr stdlib based unittest runner
 
     :return return_code: The exit code for the command. 0 for success and > 0
         for failures.
@@ -645,6 +655,7 @@ def run_command(
             top_dir=top_dir,
             test_path=test_path,
             randomize=random,
+            pytest=pytest,
         )
         if isolated:
             result = 0
@@ -669,6 +680,7 @@ def run_command(
                     randomize=random,
                     test_path=test_path,
                     top_dir=top_dir,
+                    pytest=pytest,
                 )
 
                 run_result = _run_tests(
@@ -724,6 +736,7 @@ def run_command(
                 randomize=random,
                 test_path=test_path,
                 top_dir=top_dir,
+                pytest=pytest,
             )
             if not _run_tests(cmd, until_failure):
                 # If the test was filtered, it won't have been run.

--- a/stestr/pytest_subunit.py
+++ b/stestr/pytest_subunit.py
@@ -1,0 +1,218 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# This file was forked from:
+# https://github.com/jogo/pytest-subunit/blob/f5da98f3bee2ffc8d898ced92034f11bcf8e35fe/pytest_subunit.py
+# which itself was a fork from the now archived:
+# pytest-subunit: https://github.com/lukaszo/pytest-subunit
+
+from __future__ import annotations
+
+from typing import Optional
+
+import datetime
+from io import StringIO
+import pathlib
+
+from _pytest._io import TerminalWriter
+from _pytest.terminal import TerminalReporter
+import pytest
+from subunit import StreamResultToBytes
+
+
+def to_path(testid: str) -> pathlib.PosixPath:
+    delim = "::"
+    if delim in testid:
+        path = testid.split(delim)[0]
+    else:
+        path = testid
+    return pathlib.PosixPath(path).resolve()
+
+
+# hook
+def pytest_ignore_collect(collection_path, config) -> Optional[bool]:
+    # TODO(jogo): If specify a path, use same short circuit logic
+    # Only collect files in the list
+    if config.option.subunit_load_list:
+        # TODO(jogo): memoize me
+        with open(config.option.subunit_load_list) as f:
+            testids = f.readlines()
+        filenames = [to_path(line.strip()) for line in testids]
+        for filename in filenames:
+            if str(filename).startswith(str(collection_path)):
+                # Don't ignore
+                return None
+        # Ignore everything else by default
+        return True
+    return None
+
+
+# hook
+def pytest_collection_modifyitems(session, config, items):
+    if config.option.subunit:
+        terminal_reporter = config.pluginmanager.getplugin("terminalreporter")
+        terminal_reporter.tests_count += len(items)
+    if config.option.subunit_load_list:
+        with open(config.option.subunit_load_list) as f:
+            to_run = f.readlines()
+        to_run = [line.strip() for line in to_run]
+        # print(to_run)
+        # print([item.nodeid for item in items])
+        filtered = [item for item in items if item.nodeid in to_run]
+        items[:] = filtered
+
+
+# hook
+def pytest_deselected(items):
+    """Update tests_count to not include deselected tests"""
+    if len(items) > 0:
+        pluginmanager = items[0].config.pluginmanager
+        terminal_reporter = pluginmanager.getplugin("terminalreporter")
+        if (
+            hasattr(terminal_reporter, "tests_count")
+            and terminal_reporter.tests_count > 0
+        ):
+            terminal_reporter.tests_count -= len(items)
+
+
+# hook
+def pytest_addoption(parser):
+    group = parser.getgroup("terminal reporting", "reporting", after="general")
+    group._addoption(
+        "--subunit",
+        action="store_true",
+        dest="subunit",
+        default=False,
+        help=("enable pytest-subunit"),
+    )
+    group._addoption(
+        "--load-list",
+        dest="subunit_load_list",
+        default=False,
+        help=("Path to file with list of tests to run"),
+    )
+
+
+@pytest.mark.trylast
+def pytest_configure(config):
+    if config.option.subunit:
+        # Get the standard terminal reporter plugin and replace it with our
+        standard_reporter = config.pluginmanager.getplugin("terminalreporter")
+        subunit_reporter = SubunitTerminalReporter(standard_reporter)
+        config.pluginmanager.unregister(standard_reporter)
+        config.pluginmanager.register(subunit_reporter, "terminalreporter")
+
+
+class SubunitTerminalReporter(TerminalReporter):
+    def __init__(self, reporter):
+        TerminalReporter.__init__(self, reporter.config)
+        self.tests_count = 0
+        self.reports = []
+        self.skipped = []
+        self.failed = []
+        self.result = StreamResultToBytes(self._tw._file)
+
+    @property
+    def no_summary(self):
+        return True
+
+    def _status(self, report: pytest.TestReport, status: str):
+        # task id
+        test_id = report.nodeid
+
+        # get time
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        # capture output
+        buffer = StringIO()
+        writer = TerminalWriter(file=buffer)
+        report.toterminal(writer)
+        buffer.seek(0)
+        out_bytes = buffer.read().encode("utf-8")
+
+        # send status
+        self.result.status(
+            test_id=test_id,
+            test_status=status,
+            timestamp=now,
+            file_name=report.fspath,
+            file_bytes=out_bytes,
+            mime_type="text/plain; charset=utf8",
+        )
+
+    def pytest_collectreport(self, report):
+        pass
+
+    def pytest_collection_finish(self, session):
+        if self.config.option.collectonly:
+            self._printcollecteditems(session.items)
+
+    def pytest_collection(self):
+        # Prevent shoving `collecting` message
+        pass
+
+    def report_collect(self, final=False):
+        # Prevent shoving `collecting` message
+        pass
+
+    def pytest_sessionstart(self, session):
+        # Set self._session
+        # https://github.com/pytest-dev/pytest/blob/58cf20edf08d84c5baf08f0566cc9bccbc4ec7fd/src/_pytest/terminal.py#L692
+        self._session = session
+
+    def pytest_runtest_logstart(self, nodeid, location):
+        pass
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        # always exit with exitcode 0
+        session.exitstatus = 0
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport):
+        self.reports.append(report)
+        test_id = report.nodeid
+        if report.when in ["setup", "session"]:
+            self._status(report, "exists")
+            if report.outcome == "passed":
+                self._status(report, "inprogress")
+            if report.outcome == "failed":
+                self._status(report, "fail")
+            elif report.outcome == "skipped":
+                self._status(report, "skip")
+        elif report.when in ["call"]:
+            if hasattr(report, "wasxfail"):
+                if report.skipped:
+                    self._status(report, "xfail")
+                elif report.failed:
+                    self._status(report, "uxsuccess")
+            elif report.outcome == "failed":
+                self._status(report, "fail")
+                self.failed.append(test_id)
+            elif report.outcome == "skipped":
+                self._status(report, "skip")
+                self.skipped.append(test_id)
+        elif report.when in ["teardown"]:
+            if test_id not in self.skipped and test_id not in self.failed:
+                if report.outcome == "passed":
+                    self._status(report, "success")
+                elif report.outcome == "failed":
+                    self._status(report, "fail")
+        else:
+            raise Exception(str(report))
+
+    def _printcollecteditems(self, items):
+        for item in items:
+            test_id = item.nodeid
+            self.result.status(test_id=test_id, test_status="exists")
+
+    def _determine_show_progress_info(self):
+        # Never show progress bar
+        return False


### PR DESCRIPTION
This commit adds a new runner mode to stestr that enables users to run test suites using pytest instead of unittest. This is an opt-in feature as for compatibility reasons we'll always default to using unittest, as all existing stestr users have only been leveraging unittest to run tests. A pytest plugin that adds a subunit output mode is now bundled with stestr. When the user specifies running tests with pytest it calls out to pytest just as stestr does with the integrated unittest extension today and sets the appropriate flags to enable subunit output.

To facilitate this new feature pytest is added to the stestr requirements list. I debated making it an optional dependency, but to make it easier for the significantly larger pytest user base (it's downloaded ~900x more per month) it seemed simpler to just make it a hard requirement. But I'm still not 100% on this decision so if there is sufficient pushback we can start it out as an optional dependency.

Co-Authored-By: Joe Gordon <jogo@pinterest.com>

Closes: #354

TODO:

- [ ] Add CI job to run existing tests using pytest mode (as pytest can run unittest)
- [ ] Add dedicated integration tests written using pytest instead of unittest