### PR TITLE
Disable checks failure on coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
The coverage reporting via codecov was only meant to be informational but it is now reporting CI failures in the checks table when coverage changes. This is exceedingly noisy and while we've just been ignoring it so far, removing the red X from the UI would be nice. This commit adds a codecov configuration file that explicitly lists the configuration as informational only.