### PR TITLE
Pivot PyPI publishing to use trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,17 @@ jobs:
   wheel-build:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
       - name: Install Deps
-        run: pip install -U twine wheel
+        run: pip install -U wheel
       - name: Build Artifacts
         run: |
           python setup.py sdist bdist_wheel
@@ -23,7 +26,4 @@ jobs:
         with:
           path: ./dist/stestr*
       - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: stestr-release
-        run: twine upload dist/stestr*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This commit updates the wheel job CI configuration to leverage PyPI's trusted publisher mechanism. Moving forward the bot account we've been using will be deleted (as it will require 2fa) and the stestr github repository's release workflow has been setup as a trusted publisher. This commit updates the job configuration per:

https://docs.pypi.org/trusted-publishers/using-a-publisher/

to autheticate the job directly against pypi for publishing the package files without needing any user credentials.