### PR TITLE
Update package metadata for support Python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,14 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Quality Assurance
 project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-python_requires = >=3.6
+python_requires = >=3.7
 
 [files]
 packages =


### PR DESCRIPTION
This commit updates the stestr package metadata to reflect that Python 3.12 is supported now. The previous release 4.1.0 had preliminary support for 3.12, but was blocked on our upstream dependencies needing fixes for running with 3.12 to run it in CI. This commit updates the pacakge metadata so the trove classifiers indicate that Python 3.12 is now a supported version of Python. The other thing being updated is the minimum version of Python supported in the metadata (which results in a pip error if an older version is trying to install the package) is set to 3.7, it was previously set to 3.6 but we dropped 3.6 support in: 9d5a504 which was part of the 4.1.0 release.