### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +26,7 @@ project_urls =
     Documentation = https://stestr.readthedocs.io
     Source Code = https://github.com/mtreinish/stestr
     Bug Tracker = https://github.com/mtreinish/stestr/issues
-python_requires = >=3.7
+python_requires = >=3.8
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py311,py310,py39,py38,py37,pep8
+envlist = py312,py311,py310,py39,py38,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 already reached its EOL on 2023-06-27[1].

[1] https://devguide.python.org/versions/