### PR TITLE
Adapt to tox 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
         if: runner.os != 'macOS'
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U 'tox<4'
+        run: python -m pip install -U tox
       - name: Run lint
         run: tox -epep8
   cover:
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U 'tox<4'
+        run: python -m pip install -U tox
       - name: Run coverxml
         run: tox -ecoverxml
       - name: codecov
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: Install Deps
-        run: python -m pip install -U 'tox<4'
+        run: python -m pip install -U tox
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-minversion = 1.6
+minversion = 3.18.0
 envlist = py312,py311,py310,py39,py38,pep8
-skipsdist = True
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
It seems tox 4 does not install console scripts wen skipsdist = True is set. This removes the option so that we can use the stestr command in tests.

Also, the allowlist_externals option was added in tox 3.18.0 so the minimum version should be fixed accordingly.