### PR TITLE
Remove dependency on the extras library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ testtools>=2.2.0 # MIT
 PyYAML>=3.10.0 # MIT
 voluptuous>=0.8.9 # BSD License
 tomlkit>=0.11.6 # MIT
-extras>=1.0.0

--- a/stestr/repository/memory.py
+++ b/stestr/repository/memory.py
@@ -12,8 +12,7 @@
 
 """In memory storage of test results."""
 
-from extras import try_import
-
+from collections import OrderedDict
 from io import BytesIO
 from operator import methodcaller
 
@@ -21,8 +20,6 @@ import subunit
 import testtools
 
 from stestr.repository import abstract as repository
-
-OrderedDict = try_import("collections.OrderedDict", dict)
 
 
 class RepositoryFactory(repository.AbstractRepositoryFactory):

--- a/stestr/subunit_runner/program.py
+++ b/stestr/subunit_runner/program.py
@@ -18,8 +18,6 @@ import os
 import sys
 import unittest
 
-import extras
-
 
 def filter_by_ids(suite_or_case, test_ids):
     """Remove tests from suite_or_case where their id is not in test_ids.
@@ -59,10 +57,10 @@ def filter_by_ids(suite_or_case, test_ids):
     than guessing how to reconstruct a new suite.
     """
     # Compatible objects
-    if extras.safe_hasattr(suite_or_case, "filter_by_ids"):
+    if hasattr(suite_or_case, "filter_by_ids"):
         return suite_or_case.filter_by_ids(test_ids)
     # TestCase objects.
-    if extras.safe_hasattr(suite_or_case, "id"):
+    if hasattr(suite_or_case, "id"):
         if suite_or_case.id() in test_ids:
             return suite_or_case
         else:
@@ -197,7 +195,7 @@ class TestProgram(unittest.TestProgram):
             self.runTests()
         else:
             runner = self._get_runner()
-            if extras.safe_hasattr(runner, "list"):
+            if hasattr(runner, "list"):
                 try:
                     runner.list(self.test, loader=self.testLoader)
                 except TypeError:

--- a/stestr/testlist.py
+++ b/stestr/testlist.py
@@ -14,10 +14,15 @@
 
 import io
 
-from extras import try_import
+try:
+    from subunit import ByteStreamToStreamResult as bytestream_to_streamresult
+except ImportError:
+    bytestream_to_streamresult = None
 
-bytestream_to_streamresult = try_import("subunit.ByteStreamToStreamResult")
-stream_result = try_import("testtools.testresult.doubles.StreamResult")
+try:
+    from testtools.testresult.doubles import StreamResult as stream_result
+except ImportError:
+    stream_result = None
 
 
 def write_list(stream, test_ids):


### PR DESCRIPTION
Replace the extras library by built-in items to reduce external dependency.

Note that `extras.safe_hasattr` was already removed[1] and should be removed.

[1] https://github.com/testing-cabal/extras/commit/304c046b05c72c5597f5b0568c08bbd585408973