### PR TITLE
Bump codecov action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run coverxml
         run: tox -ecoverxml
       - name: codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ./cover/coverage.xml # optional
           flags: unittests # optional

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
           name: stestr # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit bumps the codecov action version. We were previously using v3 which no longer is supported and can't be used anymore. This upgrades the action to use the latest version v5.