### PR TITLE
Update upload-artifact action in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip install -U tox
       - name: Build Docs
         run: tox -edocs
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: html_docs
           path: docs/_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
         shell: bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/stestr*
       - name: Publish to PyPi


### PR DESCRIPTION
The docs ci (and the release if that were triggered) job is failing right now because it is using the non-existent upload-artifact v3 action. To fix this issue this commit updates it to the latest version.