### PR TITLE
Update release job to work with new packaging structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.x'
       - name: Install Deps
-        run: pip install -U wheel
+        run: pip install -U build
       - name: Build Artifacts
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
         shell: bash
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
In #373 we modernized the packaging infrastructure for stestr and no longer contain a setup.py. However this PR forgot to update the release job to update how we build the artifacts for PyPI. This commit refactors the workflow to use build to create the artifacts.