### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v6
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Pip cache
         uses: actions/cache@v5
         with:
@@ -98,10 +98,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Pip cache
         uses: actions/cache@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -26,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "cliff>=2.8.0",
     "python-subunit>=1.4.0",

--- a/stestr/tests/files/tox.ini
+++ b/stestr/tests/files/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py310,py39,py38,py37,py36,pep8
+envlist = py312,py311,py310,py39,pep8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py312,py311,py310,py39,py38,pep8
+envlist = py312,py311,py310,py39,pep8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Python 3.8 already reached its EOL on 2024-10-07 [1].

[1] https://devguide.python.org/versions/