### PR TITLE
Prepare for 4.2.1 release

### DIFF
--- a/stestr/__init__.py
+++ b/stestr/__init__.py
@@ -10,4 +10,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"


### PR DESCRIPTION
This commit bumps the version string to a patch release in preparation for publishing a new release to get #377 out to fix compatibility with newer testtools releases.