### PR TITLE
Enable Python 3.14 testing and indicate support in package metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["macOS-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
This commit makes two changes, the first is adding Python 3.14 to the testing matrix, the second is it updates the package metadata to indicate that 3.14 is supported. The existing release would work fine with Python 3.14 but since it predates the release of Python 3.14 we couldn't assert it until after it was released.