### PR TITLE
Include test configuration files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,10 @@ history_list = "stestr.commands.history:HistoryList"
 history_show = "stestr.commands.history:HistoryShow"
 history_remove = "stestr.commands.history:HistoryRemove"
 
+[tool.flit.sdist]
+include = [
+    ".stestr.conf",
+    "test-requirements.txt",
+    "tox.ini",
+    "tools/find_and_rm.py",
+]


### PR DESCRIPTION
Files `.stestr.conf`, `tox.ini`, `test-requirements.txt` an `tools/find_and_rm.py` are required to run the test suite from the sdist but are currently absent from it.

Adding them to the sdist via `[tool.flit.sdist]` resolves this.

* Fixes #375